### PR TITLE
Fix(messaging): dm channel create

### DIFF
--- a/messaging/rest/request/channel.go
+++ b/messaging/rest/request/channel.go
@@ -142,8 +142,9 @@ func (r *ChannelCreate) Fill(req *http.Request) (err error) {
 	if val, ok := post["type"]; ok {
 		r.Type = val
 	}
-
-	r.Members = parseStrings(req.Form["members"])
+	if _, ok := post["members"]; ok {
+		r.Members = parseStrings(req.Form["members"])
+	}
 
 	return err
 }


### PR DESCRIPTION
There is no `members` field in request form, so the used value
was nil => only the creator is a member.