### PR TITLE
Prevent system field ambiguity

### DIFF
--- a/compose/repository/record.go
+++ b/compose/repository/record.go
@@ -355,7 +355,7 @@ func isRealRecordCol(name string) (string, bool) {
 	case
 		"recordID",
 		"id":
-		return "id", true
+		return "r.id", true
 	case
 		"module_id",
 		"owned_by",
@@ -365,7 +365,7 @@ func isRealRecordCol(name string) (string, bool) {
 		"updated_at",
 		"deleted_by",
 		"deleted_at":
-		return name, true
+		return "r." + name, true
 
 	case
 		"moduleID",
@@ -376,7 +376,7 @@ func isRealRecordCol(name string) (string, bool) {
 		"updatedAt",
 		"deletedBy",
 		"deletedAt":
-		return name[0:len(name)-2] + "_" + strings.ToLower(name[len(name)-2:]), true
+		return "r." + name[0:len(name)-2] + "_" + strings.ToLower(name[len(name)-2:]), true
 	}
 
 	return name, false

--- a/compose/repository/record_test.go
+++ b/compose/repository/record_test.go
@@ -32,14 +32,14 @@ func TestRecordFinder(t *testing.T) {
 		{
 			f: types.RecordFilter{Filter: "id = 5 AND foo = 7"},
 			match: []string{
-				"id = 5",
+				"r.id = 5",
 				"rv_foo.value = 7"},
 			args: []interface{}{"foo"},
 		},
 		{
 			f: types.RecordFilter{Sort: "id ASC, bar DESC"},
 			match: []string{
-				" id ASC",
+				" r.id ASC",
 				" rv_bar.value DESC",
 			},
 			args: []interface{}{"bar"},


### PR DESCRIPTION
___
What do you think about using the `tableAlias` constant instead of just `.r`? I think its cleaner this way.
___

Here, `compose_record`'s `deleted_at` and `compose_record_value`'s `deleted_at` were in collision. I prefixed all `compose_record`'s fields with the given alias.