### PR TITLE
Fix QL parsing for nested expressions & formatting

### DIFF
--- a/pkg/ql/ast_parser.go
+++ b/pkg/ql/ast_parser.go
@@ -194,10 +194,18 @@ checkToken:
 		goto next
 	case PARENTHESIS_OPEN:
 		p.level++
+		dpth := p.level
 		if sub, err := p.parseExpr(p.nextToken()); err != nil {
 			return nil, err
 		} else {
 			list = append(list, sub)
+		}
+		// Allow parent level to continue parsing.
+		// Example: ((A) AND (B))
+		// +1 since PARENTHESIS_CLOSE decrease level
+		if p.level > 0 && (p.level+1) != dpth {
+			p.nextToken()
+			goto next
 		}
 	default:
 		return nil, fmt.Errorf("unexpected token while parsing expression (%v)", t)

--- a/pkg/ql/squirrel.go
+++ b/pkg/ql/squirrel.go
@@ -18,7 +18,13 @@ func (nn ASTNodes) ToSql() (out string, args []interface{}, err error) {
 		if _out, _args, err = s.ToSql(); err != nil {
 			return
 		} else {
-			out = out + _out
+			if _, ok := s.(ASTNodes); ok {
+				// Nested nodes should be wrapped
+				// Example: ((A) AND (B))
+				out = out + "(" + _out + ")"
+			} else {
+				out = out + _out
+			}
 
 			args = append(args, _args...)
 		}


### PR DESCRIPTION
#### Parsing:
`((A) AND (B))` got parsed into `[ASTNodes{A}]` instead of
`[ASTNodes{A}, ASTNode{AND}, ASTNodes{B}]`.

#### Formatting into SQL:
`[ASTNodes{A}, ASTNode{AND}, ASTNodes{B}]` got formatted
into `A AND B` instead of `(A) AND (B)`.


(Will add tests when I get a-ok)
