### PR TITLE
Fix after/from/before/to MessageID filtering

### DIFF
--- a/messaging/repository/message.go
+++ b/messaging/repository/message.go
@@ -159,21 +159,25 @@ func (r message) Find(filter types.MessageFilter) (set types.MessageSet, f types
 
 	// first, exclusive
 	if f.AfterID > 0 {
+		query = query.OrderBy("m.id ASC")
 		query = query.Where(squirrel.Gt{"m.id": f.AfterID})
 	}
 
 	// from, inclusive
 	if f.FromID > 0 {
+		query = query.OrderBy("m.id ASC")
 		query = query.Where(squirrel.GtOrEq{"m.id": f.FromID})
 	}
 
 	// last, exclusive
 	if f.BeforeID > 0 {
+		query = query.OrderBy("m.id DESC")
 		query = query.Where(squirrel.Lt{"m.id": f.BeforeID})
 	}
 
 	// to, inclusive
 	if f.ToID > 0 {
+		query = query.OrderBy("m.id DESC")
 		query = query.Where(squirrel.LtOrEq{"m.id": f.ToID})
 	}
 

--- a/tests/messaging/message_search_test.go
+++ b/tests/messaging/message_search_test.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -22,6 +23,94 @@ func TestMessageSearch(t *testing.T) {
 		Status(http.StatusOK).
 		Assert(helpers.AssertNoErrors).
 		Assert(jsonpath.Len(`$.response`, 1)).
+		End()
+}
+
+func TestMessageSearchAfterID(t *testing.T) {
+	h := newHelper(t)
+	ch := h.repoMakePublicCh()
+
+	h.repoMakeMessage("searchTestMessageA", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageB", ch, h.cUser)
+	m := h.repoMakeMessage("searchTestMessageC", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageD", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageE", ch, h.cUser)
+
+	h.apiInit().
+		Get("/search/messages").
+		Query("afterMessageID", fmt.Sprintf("%d", m.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Len(`$.response`, 2)).
+		Assert(jsonpath.Equal(`$.response[0].message`, "searchTestMessageD")).
+		Assert(jsonpath.Equal(`$.response[1].message`, "searchTestMessageE")).
+		End()
+}
+
+func TestMessageSearchFromID(t *testing.T) {
+	h := newHelper(t)
+	ch := h.repoMakePublicCh()
+
+	h.repoMakeMessage("searchTestMessageA", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageB", ch, h.cUser)
+	m := h.repoMakeMessage("searchTestMessageC", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageD", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageE", ch, h.cUser)
+
+	h.apiInit().
+		Get("/search/messages").
+		Query("fromMessageID", fmt.Sprintf("%d", m.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Len(`$.response`, 3)).
+		Assert(jsonpath.Equal(`$.response[0].message`, "searchTestMessageC")).
+		Assert(jsonpath.Equal(`$.response[1].message`, "searchTestMessageD")).
+		Assert(jsonpath.Equal(`$.response[2].message`, "searchTestMessageE")).
+		End()
+}
+
+func TestMessageSearchBeforeID(t *testing.T) {
+	h := newHelper(t)
+	ch := h.repoMakePublicCh()
+
+	h.repoMakeMessage("searchTestMessageA", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageB", ch, h.cUser)
+	m := h.repoMakeMessage("searchTestMessageC", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageD", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageE", ch, h.cUser)
+
+	h.apiInit().
+		Get("/search/messages").
+		Query("beforeMessageID", fmt.Sprintf("%d", m.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Equal(`$.response[0].message`, "searchTestMessageB")).
+		Assert(jsonpath.Equal(`$.response[1].message`, "searchTestMessageA")).
+		End()
+}
+
+func TestMessageSearchToID(t *testing.T) {
+	h := newHelper(t)
+	ch := h.repoMakePublicCh()
+
+	h.repoMakeMessage("searchTestMessageA", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageB", ch, h.cUser)
+	m := h.repoMakeMessage("searchTestMessageC", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageD", ch, h.cUser)
+	h.repoMakeMessage("searchTestMessageE", ch, h.cUser)
+
+	h.apiInit().
+		Get("/search/messages").
+		Query("toMessageID", fmt.Sprintf("%d", m.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Equal(`$.response[0].message`, "searchTestMessageC")).
+		Assert(jsonpath.Equal(`$.response[1].message`, "searchTestMessageB")).
+		Assert(jsonpath.Equal(`$.response[2].message`, "searchTestMessageA")).
 		End()
 }
 


### PR DESCRIPTION
When fetching messages from a specific message (`m.id > fromMessageID`) and limiting the number of messages, the latest n messages were returned, since they were ordered in such away. This PR fixes this issue.

But... it doesn't cover cases where we want to have `fromMessageID` and `toMessageID`.
We can fix this by using sub-queries, but I'd like to ask if we know of any other "better" way.