### PR TITLE
Fix page ordering by exposing weight

### DIFF
--- a/api/compose/spec.json
+++ b/api/compose/spec.json
@@ -386,6 +386,12 @@
                             "title": "Description"
                         },
                         {
+                            "type": "int",
+                            "name": "weight",
+                            "required": false,
+                            "title": "Page tree weight"
+                        },
+                        {
                             "type": "bool",
                             "name": "visible",
                             "required": false,

--- a/compose/rest/page.go
+++ b/compose/rest/page.go
@@ -121,6 +121,7 @@ func (ctrl *Page) Update(ctx context.Context, r *request.PageUpdate) (interface{
 			Handle:      r.Handle,
 			Description: r.Description,
 			Visible:     r.Visible,
+			Weight:      r.Weight,
 		}
 	)
 

--- a/compose/rest/request/page.go
+++ b/compose/rest/request/page.go
@@ -316,6 +316,7 @@ type PageUpdate struct {
 	Title       string
 	Handle      string
 	Description string
+	Weight      int
 	Visible     bool
 	Blocks      sqlxTypes.JSONText
 }

--- a/compose/service/page.go
+++ b/compose/service/page.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/titpetric/factory"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/compose/types/page.go
+++ b/compose/types/page.go
@@ -30,7 +30,7 @@ type (
 		Children PageSet `json:"children,omitempty" db:"-"`
 
 		Visible bool `json:"visible" db:"visible"`
-		Weight  int  `json:"-" db:"weight"`
+		Weight  int  `json:"weight" db:"weight"`
 
 		CreatedAt time.Time  `db:"created_at" json:"createdAt,omitempty"`
 		UpdatedAt *time.Time `db:"updated_at" json:"updatedAt,omitempty"`


### PR DESCRIPTION
Fix page order preservation by exposing the page's weight property.
This is required since the order is 0-based.