### PR TITLE
Fix ownedBy flag preservation

### DIFF
--- a/compose/service/record.go
+++ b/compose/service/record.go
@@ -3,10 +3,11 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/cortezaproject/corteza-server/compose/service/values"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/cortezaproject/corteza-server/compose/service/values"
 
 	"github.com/pkg/errors"
 	"github.com/titpetric/factory"
@@ -554,15 +555,17 @@ func (svc record) procUpdate(invokerID uint64, m *types.Module, upd *types.Recor
 	// that we can selectively update in the repository
 	upd.Values = old.Values.Merge(upd.Values)
 
-	if upd.OwnedBy == 0 && old.OwnedBy > 0 {
-		// Owner not set/send in the payload
-		//
-		// Fallback to old owner (if set)
-		upd.OwnedBy = old.OwnedBy
-	} else {
-		// If od owner is not set, make current user
-		// the owner of the record
-		upd.OwnedBy = invokerID
+	if upd.OwnedBy == 0 {
+		if old.OwnedBy > 0 {
+			// Owner not set/send in the payload
+			//
+			// Fallback to old owner (if set)
+			upd.OwnedBy = old.OwnedBy
+		} else {
+			// If od owner is not set, make current user
+			// the owner of the record
+			upd.OwnedBy = invokerID
+		}
 	}
 
 	// Run validation of the updated records

--- a/compose/service/record_test.go
+++ b/compose/service/record_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cortezaproject/corteza-server/compose/service/values"
 	"github.com/cortezaproject/corteza-server/compose/types"
 	"github.com/cortezaproject/corteza-server/pkg/permissions"
 )
@@ -88,4 +89,62 @@ func TestDefaultValueSetting(t *testing.T) {
 	chk(out, "single", 0, "s")
 	chk(out, "multi", 0, "m1")
 	chk(out, "multi", 1, "m2")
+}
+
+func TestProcUpdateOwnerPreservation(t *testing.T) {
+	var (
+		a = assert.New(t)
+
+		svc = record{
+			sanitizer: values.Sanitizer(),
+			validator: values.Validator(),
+		}
+
+		mod = &types.Module{
+			Fields: types.ModuleFieldSet{},
+		}
+
+		oldRec = &types.Record{
+			OwnedBy: 1,
+			Values:  types.RecordValueSet{},
+		}
+		newRec = &types.Record{
+			OwnedBy: 0,
+			Values:  types.RecordValueSet{},
+		}
+	)
+
+	svc.procUpdate(10, mod, newRec, oldRec)
+	a.Equal(newRec.OwnedBy, uint64(1))
+	svc.procUpdate(10, mod, newRec, oldRec)
+	a.Equal(newRec.OwnedBy, uint64(1))
+}
+
+func TestProcUpdateOwnerChanged(t *testing.T) {
+	var (
+		a = assert.New(t)
+
+		svc = record{
+			sanitizer: values.Sanitizer(),
+			validator: values.Validator(),
+		}
+
+		mod = &types.Module{
+			Fields: types.ModuleFieldSet{},
+		}
+
+		oldRec = &types.Record{
+			OwnedBy: 1,
+			Values:  types.RecordValueSet{},
+		}
+		newRec = &types.Record{
+			OwnedBy: 9,
+			Values:  types.RecordValueSet{},
+		}
+	)
+
+	svc.procUpdate(10, mod, newRec, oldRec)
+	a.Equal(newRec.OwnedBy, uint64(9))
+	svc.procUpdate(10, mod, newRec, oldRec)
+	a.Equal(newRec.OwnedBy, uint64(9))
 }


### PR DESCRIPTION
If procUpdate was ran multiple times, ownedBy flag changed to
current user.
