### PR TITLE
Add support for batch record operations

### DIFF
--- a/api/compose/spec.json
+++ b/api/compose/spec.json
@@ -898,8 +898,14 @@
             {
               "type": "types.RecordValueSet",
               "name": "values",
-              "required": true,
+              "required": false,
               "title": "Record values"
+            },
+            {
+              "type": "types.BulkRecordSet",
+              "name": "records",
+              "required": false,
+              "title": "Records"
             }
           ]
         }
@@ -938,8 +944,14 @@
             {
               "type": "types.RecordValueSet",
               "name": "values",
-              "required": true,
+              "required": false,
               "title": "Record values"
+            },
+            {
+              "type": "types.BulkRecordSet",
+              "name": "records",
+              "required": false,
+              "title": "Records"
             }
           ]
         }

--- a/api/compose/spec/record.json
+++ b/api/compose/spec/record.json
@@ -241,9 +241,15 @@
         "post": [
           {
             "name": "values",
-            "required": true,
+            "required": false,
             "title": "Record values",
             "type": "types.RecordValueSet"
+          },
+          {
+            "name": "records",
+            "required": false,
+            "title": "Records",
+            "type": "types.BulkRecordSet"
           }
         ]
       }
@@ -281,9 +287,15 @@
         "post": [
           {
             "name": "values",
-            "required": true,
+            "required": false,
             "title": "Record values",
             "type": "types.RecordValueSet"
+          },
+          {
+            "name": "records",
+            "required": false,
+            "title": "Records",
+            "type": "types.BulkRecordSet"
           }
         ]
       }

--- a/compose/rest/request/record.go
+++ b/compose/rest/request/record.go
@@ -712,6 +712,10 @@ type RecordCreate struct {
 	rawValues string
 	Values    types.RecordValueSet
 
+	hasRecords bool
+	rawRecords string
+	Records    types.BulkRecordSet
+
 	hasNamespaceID bool
 	rawNamespaceID string
 	NamespaceID    uint64 `json:",string"`
@@ -731,6 +735,7 @@ func (r RecordCreate) Auditable() map[string]interface{} {
 	var out = map[string]interface{}{}
 
 	out["values"] = r.Values
+	out["records"] = r.Records
 	out["namespaceID"] = r.NamespaceID
 	out["moduleID"] = r.ModuleID
 
@@ -868,6 +873,10 @@ type RecordUpdate struct {
 	hasValues bool
 	rawValues string
 	Values    types.RecordValueSet
+
+	hasRecords bool
+	rawRecords string
+	Records    types.BulkRecordSet
 }
 
 // NewRecordUpdate request
@@ -883,6 +892,7 @@ func (r RecordUpdate) Auditable() map[string]interface{} {
 	out["namespaceID"] = r.NamespaceID
 	out["moduleID"] = r.ModuleID
 	out["values"] = r.Values
+	out["records"] = r.Records
 
 	return out
 }
@@ -1908,6 +1918,21 @@ func (r *RecordCreate) GetValues() types.RecordValueSet {
 	return r.Values
 }
 
+// HasRecords returns true if records was set
+func (r *RecordCreate) HasRecords() bool {
+	return r.hasRecords
+}
+
+// RawRecords returns raw value of records parameter
+func (r *RecordCreate) RawRecords() string {
+	return r.rawRecords
+}
+
+// GetRecords returns casted value of  records parameter
+func (r *RecordCreate) GetRecords() types.BulkRecordSet {
+	return r.Records
+}
+
 // HasNamespaceID returns true if namespaceID was set
 func (r *RecordCreate) HasNamespaceID() bool {
 	return r.hasNamespaceID
@@ -2041,6 +2066,21 @@ func (r *RecordUpdate) RawValues() string {
 // GetValues returns casted value of  values parameter
 func (r *RecordUpdate) GetValues() types.RecordValueSet {
 	return r.Values
+}
+
+// HasRecords returns true if records was set
+func (r *RecordUpdate) HasRecords() bool {
+	return r.hasRecords
+}
+
+// RawRecords returns raw value of records parameter
+func (r *RecordUpdate) RawRecords() string {
+	return r.rawRecords
+}
+
+// GetRecords returns casted value of  records parameter
+func (r *RecordUpdate) GetRecords() types.BulkRecordSet {
+	return r.Records
 }
 
 // HasRecordIDs returns true if recordIDs was set

--- a/compose/service/record.go
+++ b/compose/service/record.go
@@ -86,6 +86,7 @@ type (
 
 		Create(record *types.Record) (*types.Record, error)
 		Update(record *types.Record) (*types.Record, error)
+		Bulk(oo ...*types.BulkRecordOperation) (types.RecordSet, error)
 
 		DeleteByID(namespaceID, moduleID uint64, recordID ...uint64) error
 
@@ -354,71 +355,231 @@ func (svc record) Export(filter types.RecordFilter, enc Encoder) error {
 	return set.Walk(enc.Record)
 }
 
-func (svc record) Create(new *types.Record) (rec *types.Record, err error) {
+// Bulk handles provided set of bulk record operations.
+// It's able to create or update records in a single transaction.
+//
+// Feature used mainly by Record Lines, but should be used when ever we wish to perform
+// multiple operations over records.
+func (svc record) Bulk(oo ...*types.BulkRecordOperation) (rec types.RecordSet, err error) {
+	ctr := map[string]uint{}
+	return rec, svc.db.Transaction(func() (err error) {
+		for _, p := range oo {
+			r := p.Record
+			res := fmt.Sprintf("compose:module:%d", r.ModuleID)
+			if _, ok := ctr[res]; !ok {
+				ctr[res] = 0
+			}
+
+			// Handle any pre processing, such as defining parent recordID.
+			if p.LinkBy != "" {
+				// As is, we can use the first record as the master record.
+				// This is valid, since we do not allow this, if the master record is not defined
+				r.Values = r.Values.Set(&types.RecordValue{
+					Name:  p.LinkBy,
+					Value: strconv.FormatUint(rec[0].ID, 10),
+					Ref:   rec[0].ID,
+				})
+			}
+
+			switch p.Operation {
+			case types.OperationTypeCreate:
+				r, err = svc.create(r)
+				break
+
+			case types.OperationTypeUpdate:
+				r, err = svc.update(r)
+				break
+
+			default:
+				return errors.Errorf("unknown record bulk operation %s", p.Operation)
+			}
+
+			if err != nil {
+				if rve, ok := err.(*types.RecordValueErrorSet); ok {
+					// Attach additional meta to each value error for FE identification
+					for _, re := range rve.Set {
+						re.Meta["resource"] = res
+						re.Meta["item"] = ctr[res]
+					}
+					return rve
+				}
+				return err
+			}
+
+			rec = append(rec, r)
+			ctr[res]++
+		}
+		return nil
+	})
+}
+
+// Raw create function that is responsible for value validation, event dispatching
+// and creation.
+func (svc record) create(new *types.Record) (rec *types.Record, err error) {
 	var invokerID = auth.GetIdentityFromContext(svc.ctx).Identity()
 
-	return rec, svc.db.Transaction(func() (err error) {
-		var (
-			ns *types.Namespace
-			m  *types.Module
-		)
+	var (
+		ns *types.Namespace
+		m  *types.Module
+	)
 
-		ns, m, _, err = svc.loadCombo(new.NamespaceID, new.ModuleID, 0)
-		if err != nil {
-			return
-		}
+	ns, m, _, err = svc.loadCombo(new.NamespaceID, new.ModuleID, 0)
+	if err != nil {
+		return nil, err
+	}
 
-		if !svc.ac.CanCreateRecord(svc.ctx, m) {
-			return ErrNoCreatePermissions.withStack()
-		}
+	if !svc.ac.CanCreateRecord(svc.ctx, m) {
+		return nil, ErrNoCreatePermissions.withStack()
+	}
 
-		if err = svc.generalValueSetValidation(m, new.Values); err != nil {
-			return
-		}
+	if err = svc.generalValueSetValidation(m, new.Values); err != nil {
+		return nil, err
+	}
 
-		var (
-			rve *types.RecordValueErrorSet
-		)
+	var (
+		rve *types.RecordValueErrorSet
+	)
 
-		if svc.optEmitEvents {
-			// Handle input payload
-			if rve = svc.procCreate(invokerID, m, new); !rve.IsValid() {
-				return rve
-			}
-
-			new.Values = svc.formatter.Run(m, new.Values)
-			if err = svc.eventbus.WaitFor(svc.ctx, event.RecordBeforeCreate(new, nil, m, ns, rve)); err != nil {
-				return
-			} else if !rve.IsValid() {
-				return rve
-			}
-		}
-
-		// Assign defaults (only on missing values)
-		new.Values = svc.setDefaultValues(m, new.Values)
-
-		// Handle payload from automation scripts
+	if svc.optEmitEvents {
+		// Handle input payload
 		if rve = svc.procCreate(invokerID, m, new); !rve.IsValid() {
-			return rve
+			return nil, rve
 		}
 
-		if new, err = svc.recordRepo.Create(new); err != nil {
-			return
+		new.Values = svc.formatter.Run(m, new.Values)
+		if err = svc.eventbus.WaitFor(svc.ctx, event.RecordBeforeCreate(new, nil, m, ns, rve)); err != nil {
+			return nil, err
+		} else if !rve.IsValid() {
+			return nil, rve
+		}
+	}
+
+	// Assign defaults (only on missing values)
+	new.Values = svc.setDefaultValues(m, new.Values)
+
+	// Handle payload from automation scripts
+	if rve = svc.procCreate(invokerID, m, new); !rve.IsValid() {
+		return nil, rve
+	}
+
+	if new, err = svc.recordRepo.Create(new); err != nil {
+		return nil, err
+	}
+
+	if err = svc.recordRepo.UpdateValues(new.ID, new.Values); err != nil {
+		return nil, err
+	}
+
+	// At this point we can return the value
+	rec = new
+
+	if svc.optEmitEvents {
+		defer func() {
+			new.Values = svc.formatter.Run(m, new.Values)
+			svc.eventbus.Dispatch(svc.ctx, event.RecordAfterCreateImmutable(new, nil, m, ns, nil))
+		}()
+	}
+	return
+}
+
+// Raw update function that is responsible for value validation, event dispatching
+// and update.
+func (svc record) update(upd *types.Record) (rec *types.Record, err error) {
+	var invokerID = auth.GetIdentityFromContext(svc.ctx).Identity()
+
+	if upd.ID == 0 {
+		return nil, ErrInvalidID.withStack()
+	}
+
+	ns, m, old, err := svc.loadCombo(upd.NamespaceID, upd.ModuleID, upd.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = svc.generalValueSetValidation(m, upd.Values); err != nil {
+		return nil, err
+	}
+
+	// Test if stale (update has an older version of data)
+	if isStale(upd.UpdatedAt, old.UpdatedAt, old.CreatedAt) {
+		return nil, ErrStaleData.withStack()
+	}
+
+	if !svc.ac.CanUpdateRecord(svc.ctx, m) {
+		return nil, ErrNoUpdatePermissions.withStack()
+	}
+
+	// Preload old record values so we can send it together with event
+	if err = svc.preloadValues(m, old); err != nil {
+		return nil, err
+	}
+
+	var (
+		rve *types.RecordValueErrorSet
+	)
+
+	if svc.optEmitEvents {
+		// Handle input payload
+		if rve = svc.procUpdate(invokerID, m, upd, old); !rve.IsValid() {
+			return nil, rve
 		}
 
-		if err = svc.recordRepo.UpdateValues(new.ID, new.Values); err != nil {
-			return
-		}
+		// Before we pass values to record-before-update handling events
+		// values needs do be cleaned up
+		//
+		// Value merge inside procUpdate sets delete flag we need
+		// when changes are applied but we do not want deleted values
+		// to be sent to handler
+		upd.Values = upd.Values.GetClean()
 
-		// At this point we can return the value
-		rec = new
+		// Before we pass values to automation scripts, they should be formatted
+		upd.Values = svc.formatter.Run(m, upd.Values)
 
-		if svc.optEmitEvents {
-			defer func() {
-				new.Values = svc.formatter.Run(m, new.Values)
-				svc.eventbus.Dispatch(svc.ctx, event.RecordAfterCreateImmutable(new, nil, m, ns, nil))
-			}()
+		// Scripts can (besides simple error value) return complex record value error set
+		// that is passed back to the UI or any other API consumer
+		//
+		// rve (record-validation-errorset) struct is passed so it can be
+		// used & filled by automation scripts
+		if err = svc.eventbus.WaitFor(svc.ctx, event.RecordBeforeUpdate(upd, old, m, ns, rve)); err != nil {
+			return nil, err
+		} else if !rve.IsValid() {
+			return nil, rve
 		}
+	}
+
+	// Handle payload from automation scripts
+	if rve = svc.procUpdate(invokerID, m, upd, old); !rve.IsValid() {
+		return nil, rve
+	}
+
+	if upd, err = svc.recordRepo.Update(upd); err != nil {
+		return nil, err
+	}
+
+	if err = svc.recordRepo.UpdateValues(upd.ID, upd.Values); err != nil {
+		return nil, err
+	}
+
+	// Final value cleanup
+	// These (clean) values are returned (and sent to after-update handler)
+	upd.Values = upd.Values.GetClean()
+
+	// At this point we can return the value
+	rec = upd
+
+	if svc.optEmitEvents {
+		defer func() {
+			// Before we pass values to automation scripts, they should be formatted
+			upd.Values = svc.formatter.Run(m, upd.Values)
+			svc.eventbus.Dispatch(svc.ctx, event.RecordAfterUpdateImmutable(upd, old, m, ns, nil))
+		}()
+	}
+	return
+}
+
+func (svc record) Create(new *types.Record) (rec *types.Record, err error) {
+	return rec, svc.db.Transaction(func() (err error) {
+		rec, err = svc.create(new)
 		return
 	})
 }
@@ -459,96 +620,8 @@ func (svc record) procCreate(invokerID uint64, m *types.Module, new *types.Recor
 }
 
 func (svc record) Update(upd *types.Record) (rec *types.Record, err error) {
-	var invokerID = auth.GetIdentityFromContext(svc.ctx).Identity()
-
 	return rec, svc.db.Transaction(func() (err error) {
-		if upd.ID == 0 {
-			return ErrInvalidID.withStack()
-		}
-
-		ns, m, old, err := svc.loadCombo(upd.NamespaceID, upd.ModuleID, upd.ID)
-		if err != nil {
-			return
-		}
-
-		if err = svc.generalValueSetValidation(m, upd.Values); err != nil {
-			return
-		}
-
-		// Test if stale (update has an older version of data)
-		if isStale(upd.UpdatedAt, old.UpdatedAt, old.CreatedAt) {
-			return ErrStaleData.withStack()
-		}
-
-		if !svc.ac.CanUpdateRecord(svc.ctx, m) {
-			return ErrNoUpdatePermissions.withStack()
-		}
-
-		// Preload old record values so we can send it together with event
-		if err = svc.preloadValues(m, old); err != nil {
-			return
-		}
-
-		var (
-			rve *types.RecordValueErrorSet
-		)
-
-		if svc.optEmitEvents {
-			// Handle input payload
-			if rve = svc.procUpdate(invokerID, m, upd, old); !rve.IsValid() {
-				return rve
-			}
-
-			// Before we pass values to record-before-update handling events
-			// values needs do be cleaned up
-			//
-			// Value merge inside procUpdate sets delete flag we need
-			// when changes are applied but we do not want deleted values
-			// to be sent to handler
-			upd.Values = upd.Values.GetClean()
-
-			// Before we pass values to automation scripts, they should be formatted
-			upd.Values = svc.formatter.Run(m, upd.Values)
-
-			// Scripts can (besides simple error value) return complex record value error set
-			// that is passed back to the UI or any other API consumer
-			//
-			// rve (record-validation-errorset) struct is passed so it can be
-			// used & filled by automation scripts
-			if err = svc.eventbus.WaitFor(svc.ctx, event.RecordBeforeUpdate(upd, old, m, ns, rve)); err != nil {
-				return
-			} else if !rve.IsValid() {
-				return rve
-			}
-		}
-
-		// Handle payload from automation scripts
-		if rve = svc.procUpdate(invokerID, m, upd, old); !rve.IsValid() {
-			return rve
-		}
-
-		if upd, err = svc.recordRepo.Update(upd); err != nil {
-			return
-		}
-
-		if err = svc.recordRepo.UpdateValues(upd.ID, upd.Values); err != nil {
-			return
-		}
-
-		// Final value cleanup
-		// These (clean) values are returned (and sent to after-update handler)
-		upd.Values = upd.Values.GetClean()
-
-		// At this point we can return the value
-		rec = upd
-
-		if svc.optEmitEvents {
-			defer func() {
-				// Before we pass values to automation scripts, they should be formatted
-				upd.Values = svc.formatter.Run(m, upd.Values)
-				svc.eventbus.Dispatch(svc.ctx, event.RecordAfterUpdateImmutable(upd, old, m, ns, nil))
-			}()
-		}
+		rec, err = svc.update(upd)
 		return
 	})
 }

--- a/compose/types/record.go
+++ b/compose/types/record.go
@@ -9,6 +9,16 @@ import (
 )
 
 type (
+	bulkPreProcess func(m, r *Record) (*Record, error)
+
+	OperationType string
+
+	BulkRecordOperation struct {
+		Record    *Record
+		LinkBy    string
+		Operation OperationType
+	}
+
 	// Record is a stored row in the `record` table
 	Record struct {
 		ID       uint64 `json:"recordID,string" db:"id"`
@@ -38,6 +48,12 @@ type (
 
 		Deleted rh.FilterState `json:"deleted"`
 	}
+)
+
+const (
+	OperationTypeCreate OperationType = "create"
+	OperationTypeUpdate OperationType = "update"
+	OperationTypeDelete OperationType = "delete"
 )
 
 // UserIDs returns a slice of user IDs from all items in the set

--- a/compose/types/rest.go
+++ b/compose/types/rest.go
@@ -1,0 +1,38 @@
+package types
+
+type (
+	BulkRecord struct {
+		RefField string    `json:"refField,omitempty"`
+		Set      RecordSet `json:"set,omitempty"`
+	}
+
+	BulkRecordSet []*BulkRecord
+)
+
+func (set BulkRecordSet) ToBulkOperations(dftModule uint64, dftNamespace uint64) (oo []*BulkRecordOperation, err error) {
+	for _, br := range set {
+		for _, rr := range br.Set {
+			// No use in allowing cross-namespace record creation.
+			rr.NamespaceID = dftNamespace
+
+			// default module
+			if rr.ModuleID == 0 {
+				rr.ModuleID = dftModule
+			}
+			b := &BulkRecordOperation{
+				Record:    rr,
+				Operation: OperationTypeUpdate,
+				LinkBy:    br.RefField,
+			}
+
+			// If no RecordID is defined, we should create it
+			if rr.ID == 0 {
+				b.Operation = OperationTypeCreate
+			}
+
+			oo = append(oo, b)
+		}
+	}
+
+	return
+}

--- a/compose/types/rest.go
+++ b/compose/types/rest.go
@@ -30,6 +30,10 @@ func (set BulkRecordSet) ToBulkOperations(dftModule uint64, dftNamespace uint64)
 				b.Operation = OperationTypeCreate
 			}
 
+			if rr.DeletedAt != nil {
+				b.Operation = OperationTypeDelete
+			}
+
 			oo = append(oo, b)
 		}
 	}

--- a/compose/types/rest_test.go
+++ b/compose/types/rest_test.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToBulkOperations(t *testing.T) {
+	tests := []struct {
+		name string
+		bb   BulkRecordSet
+		size int
+	}{
+		{
+			name: "Return nothing if empty",
+			bb:   BulkRecordSet{},
+			size: 0,
+		},
+
+		{
+			name: "Return all sets all records",
+			bb: BulkRecordSet{
+				&BulkRecord{
+					RefField: "f1",
+					Set:      RecordSet{&Record{}},
+				},
+				&BulkRecord{
+					RefField: "f2",
+					Set:      RecordSet{&Record{}},
+				},
+			},
+			size: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr, err := tt.bb.ToBulkOperations(0, 0)
+			if err != nil {
+				t.Errorf("unexpected error = %v,", err)
+			}
+
+			require.Equal(t,
+				tt.size,
+				len(rr))
+		})
+	}
+}
+
+func TestToBulkOperationsDefaultModule(t *testing.T) {
+	bb := BulkRecordSet{
+		&BulkRecord{
+			RefField: "f1",
+			Set: RecordSet{&Record{
+				ModuleID: 1000,
+			}},
+		},
+		&BulkRecord{
+			RefField: "f2",
+			Set:      RecordSet{&Record{}},
+		},
+	}
+
+	rr, err := bb.ToBulkOperations(2000, 0)
+	if err != nil {
+		t.Errorf("unexpected error = %v,", err)
+	}
+
+	require.Equal(t,
+		uint64(1000),
+		rr[0].Record.ModuleID,
+	)
+
+	require.Equal(t,
+		uint64(2000),
+		rr[1].Record.ModuleID,
+		"Expected default value of \n%d got \n%d",
+		2000,
+		rr[1].Record.ModuleID,
+	)
+}
+
+func TestToBulkOperationsDetermineOperation(t *testing.T) {
+	bb := BulkRecordSet{
+		&BulkRecord{
+			RefField: "f1",
+			Set: RecordSet{&Record{
+				ID: 1000,
+			}},
+		},
+		&BulkRecord{
+			RefField: "f2",
+			Set:      RecordSet{&Record{}},
+		},
+	}
+
+	rr, err := bb.ToBulkOperations(0, 0)
+	if err != nil {
+		t.Errorf("unexpected error = %v,", err)
+	}
+
+	require.Equal(t,
+		OperationTypeUpdate,
+		rr[0].Operation,
+	)
+
+	require.Equal(t,
+		OperationTypeCreate,
+		rr[1].Operation,
+	)
+}

--- a/docs/compose/README.md
+++ b/docs/compose/README.md
@@ -127,9 +127,7 @@
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/automation/` | HTTP/S | GET |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/automation/` | HTTP/S | GET |  |
 
 #### Request parameters
 
@@ -148,9 +146,7 @@ Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.cru
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/automation/{bundle}-{type}.{ext}` | HTTP/S | GET |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/automation/{bundle}-{type}.{ext}` | HTTP/S | GET |  |
 
 #### Request parameters
 
@@ -166,9 +162,7 @@ Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.cru
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/automation/trigger` | HTTP/S | POST |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/automation/trigger` | HTTP/S | POST |  |
 
 #### Request parameters
 
@@ -979,7 +973,8 @@ Compose records
 
 | Parameter | Type | Method | Description | Default | Required? |
 | --------- | ---- | ------ | ----------- | ------- | --------- |
-| values | types.RecordValueSet | POST | Record values | N/A | YES |
+| values | types.RecordValueSet | POST | Record values | N/A | NO |
+| records | types.BulkRecordSet | POST | Records | N/A | NO |
 | namespaceID | uint64 | PATH | Namespace ID | N/A | YES |
 | moduleID | uint64 | PATH | Module ID | N/A | YES |
 
@@ -1014,7 +1009,8 @@ Compose records
 | recordID | uint64 | PATH | Record ID | N/A | YES |
 | namespaceID | uint64 | PATH | Namespace ID | N/A | YES |
 | moduleID | uint64 | PATH | Module ID | N/A | YES |
-| values | types.RecordValueSet | POST | Record values | N/A | YES |
+| values | types.RecordValueSet | POST | Record values | N/A | NO |
+| records | types.BulkRecordSet | POST | Records | N/A | NO |
 
 ## Delete record row from module section
 

--- a/docs/system/README.md
+++ b/docs/system/README.md
@@ -416,9 +416,7 @@
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/automation/` | HTTP/S | GET |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/automation/` | HTTP/S | GET |  |
 
 #### Request parameters
 
@@ -437,9 +435,7 @@ Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.cru
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/automation/{bundle}-{type}.{ext}` | HTTP/S | GET |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/automation/{bundle}-{type}.{ext}` | HTTP/S | GET |  |
 
 #### Request parameters
 
@@ -455,9 +451,7 @@ Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.cru
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/automation/trigger` | HTTP/S | POST |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/automation/trigger` | HTTP/S | POST |  |
 
 #### Request parameters
 
@@ -1154,9 +1148,7 @@ An organisation may have many roles. Roles may have many channels available. Acc
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/subscription/` | HTTP/S | GET |
-Warning: implode(): Invalid arguments passed in /private/tmp/Users/darh/Work.crust/corteza-server/codegen/templates/README.tpl on line 32
- |
+| `/subscription/` | HTTP/S | GET |  |
 
 #### Request parameters
 

--- a/tests/compose/record_batch_test.go
+++ b/tests/compose/record_batch_test.go
@@ -54,6 +54,33 @@ func TestRecordUpdate_batch(t *testing.T) {
 		End()
 }
 
+func TestRecordDelete_batch(t *testing.T) {
+	h := newHelper(t)
+
+	ns := h.repoMakeNamespace("batch testing namespace")
+	module := h.repoMakeRecordModuleWithFieldsOnNs("record testing module", ns)
+	childModule := h.repoMakeRecordModuleWithFieldsOnNs("record testing module child", ns)
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.update")
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.delete")
+
+	record := h.repoMakeRecord(module)
+	childRecord := h.repoMakeRecord(childModule, &types.RecordValue{Name: "another_record", Value: strconv.FormatUint(record.ID, 10), Ref: record.ID})
+
+	h.apiInit().
+		Post(fmt.Sprintf("/namespace/%d/module/%d/record/%d", module.NamespaceID, module.ID, record.ID)).
+		JSON(fmt.Sprintf(`{"values": [{"name": "name", "value": "Some Name"}], "records": [{"refField": "another_record", "set": [{"deletedAt": "2020-05-15T15:01:02+02:00", "moduleID": "%d", "recordID": "%d", "values": [{"name": "name", "value": "Another Name"}]}]}]}`, childModule.ID, childRecord.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Equal(`$.response.recordID`, strconv.FormatUint(record.ID, 10))).
+		Assert(jsonpath.Len(`$.response.records`, 1)).
+		Assert(jsonpath.Equal(`$.response.records[0].recordID`, strconv.FormatUint(childRecord.ID, 10))).
+		End()
+
+	_, err := h.repoRecord().FindByID(module.NamespaceID, childRecord.ID)
+	h.a.Error(err, "compose.repository.RecordNotFound")
+}
+
 func TestRecordMixed_batch(t *testing.T) {
 	h := newHelper(t)
 

--- a/tests/compose/record_batch_test.go
+++ b/tests/compose/record_batch_test.go
@@ -1,0 +1,80 @@
+package compose
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/cortezaproject/corteza-server/compose/types"
+	"github.com/cortezaproject/corteza-server/tests/helpers"
+	jsonpath "github.com/steinfletcher/apitest-jsonpath"
+)
+
+func TestRecordCreate_batch(t *testing.T) {
+	h := newHelper(t)
+
+	ns := h.repoMakeNamespace("batch testing namespace")
+	module := h.repoMakeRecordModuleWithFieldsOnNs("record testing module", ns)
+	childModule := h.repoMakeRecordModuleWithFieldsOnNs("record testing module child", ns)
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.create")
+
+	h.apiInit().
+		Post(fmt.Sprintf("/namespace/%d/module/%d/record/", module.NamespaceID, module.ID)).
+		JSON(fmt.Sprintf(`{"values": [], "records": [{"refField": "another_record", "set": [{"moduleID": "%d", "values": []}]}]}`, childModule.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Present(`$.response.recordID`)).
+		Assert(jsonpath.Len(`$.response.records`, 1)).
+		Assert(jsonpath.Present(`$.response.records[0].recordID`)).
+		End()
+}
+
+func TestRecordUpdate_batch(t *testing.T) {
+	h := newHelper(t)
+
+	ns := h.repoMakeNamespace("batch testing namespace")
+	module := h.repoMakeRecordModuleWithFieldsOnNs("record testing module", ns)
+	childModule := h.repoMakeRecordModuleWithFieldsOnNs("record testing module child", ns)
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.update")
+
+	record := h.repoMakeRecord(module)
+	childRecord := h.repoMakeRecord(childModule, &types.RecordValue{Name: "another_record", Value: strconv.FormatUint(record.ID, 10), Ref: record.ID})
+
+	h.apiInit().
+		Post(fmt.Sprintf("/namespace/%d/module/%d/record/%d", module.NamespaceID, module.ID, record.ID)).
+		JSON(fmt.Sprintf(`{"values": [{"name": "name", "value": "Some Name"}], "records": [{"refField": "another_record", "set": [{"moduleID": "%d", "recordID": "%d", "values": [{"name": "name", "value": "Another Name"}]}]}]}`, childModule.ID, childRecord.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Equal(`$.response.recordID`, strconv.FormatUint(record.ID, 10))).
+		Assert(jsonpath.Len(`$.response.records`, 1)).
+		Assert(jsonpath.Equal(`$.response.records[0].recordID`, strconv.FormatUint(childRecord.ID, 10))).
+		End()
+}
+
+func TestRecordMixed_batch(t *testing.T) {
+	h := newHelper(t)
+
+	ns := h.repoMakeNamespace("batch testing namespace")
+	module := h.repoMakeRecordModuleWithFieldsOnNs("record testing module", ns)
+	childModule := h.repoMakeRecordModuleWithFieldsOnNs("record testing module child", ns)
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.update")
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.create")
+
+	record := h.repoMakeRecord(module)
+	childRecord := h.repoMakeRecord(childModule, &types.RecordValue{Name: "another_record", Value: strconv.FormatUint(record.ID, 10), Ref: record.ID})
+
+	h.apiInit().
+		Post(fmt.Sprintf("/namespace/%d/module/%d/record/%d", module.NamespaceID, module.ID, record.ID)).
+		JSON(fmt.Sprintf(`{"values": [{"name": "name", "value": "Some Name"}], "records": [{"refField": "another_record", "set": [{"moduleID": "%d", "values": [{"name": "name", "value": "Added Name"}]},{"moduleID": "%d", "recordID": "%d", "values": [{"name": "name", "value": "Another Name"}]}]}]}`, childModule.ID, childModule.ID, childRecord.ID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Equal(`$.response.recordID`, strconv.FormatUint(record.ID, 10))).
+		Assert(jsonpath.Len(`$.response.records`, 2)).
+		Assert(jsonpath.Present(`$.response.records[0].recordID`)).
+		Assert(jsonpath.Equal(`$.response.records[1].recordID`, strconv.FormatUint(childRecord.ID, 10))).
+		End()
+}

--- a/tests/compose/record_test.go
+++ b/tests/compose/record_test.go
@@ -30,6 +30,37 @@ func (h helper) repoRecord() repository.RecordRepository {
 	return repository.Record(context.Background(), db())
 }
 
+func (h helper) repoMakeRecordModuleWithFieldsOnNs(name string, namespace *types.Namespace, ff ...*types.ModuleField) *types.Module {
+	h.allow(types.NamespacePermissionResource.AppendWildcard(), "read")
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "read")
+	h.allow(types.ModulePermissionResource.AppendWildcard(), "record.read")
+
+	if len(ff) == 0 {
+		// Default fields
+		ff = types.ModuleFieldSet{
+			&types.ModuleField{
+				Name: "name",
+			},
+			&types.ModuleField{
+				Name: "email",
+			},
+			&types.ModuleField{
+				Name:  "options",
+				Multi: true,
+			},
+			&types.ModuleField{
+				Name: "description",
+			},
+			&types.ModuleField{
+				Name: "another_record",
+				Kind: "Record",
+			},
+		}
+	}
+
+	return h.repoMakeModule(namespace, name, ff...)
+}
+
 func (h helper) repoMakeRecordModuleWithFields(name string, ff ...*types.ModuleField) *types.Module {
 	namespace := h.repoMakeNamespace("record testing namespace")
 


### PR DESCRIPTION
Allow bulk record operations in a single request & transaction.
Feature required for the upcoming Record List feature.

The implementation is BC with "old" API clients.

TODO:
* [x] Checkup/cleanup,
* [x] tests.