### PR TITLE
Add weight to page create

### DIFF
--- a/api/compose/spec.json
+++ b/api/compose/spec.json
@@ -277,6 +277,12 @@
               "title": "Description"
             },
             {
+              "type": "int",
+              "name": "weight",
+              "required": false,
+              "title": "Page tree weight"
+            },
+            {
               "type": "bool",
               "name": "visible",
               "required": false,

--- a/api/compose/spec/page.json
+++ b/api/compose/spec/page.json
@@ -114,6 +114,12 @@
             "type": "string"
           },
           {
+            "name": "weight",
+            "required": false,
+            "title": "Page tree weight",
+            "type": "int"
+          },
+          {
             "name": "visible",
             "required": false,
             "title": "Visible in navigation",

--- a/compose/rest/page.go
+++ b/compose/rest/page.go
@@ -87,6 +87,7 @@ func (ctrl *Page) Create(ctx context.Context, r *request.PageCreate) (interface{
 			Handle:      r.Handle,
 			Description: r.Description,
 			Visible:     r.Visible,
+			Weight:      r.Weight,
 		}
 	)
 

--- a/compose/rest/request/page.go
+++ b/compose/rest/request/page.go
@@ -192,6 +192,10 @@ type PageCreate struct {
 	rawDescription string
 	Description    string
 
+	hasWeight bool
+	rawWeight string
+	Weight    int
+
 	hasVisible bool
 	rawVisible string
 	Visible    bool
@@ -278,6 +282,11 @@ func (r *PageCreate) Fill(req *http.Request) (err error) {
 		r.hasDescription = true
 		r.rawDescription = val
 		r.Description = val
+	}
+	if val, ok := post["weight"]; ok {
+		r.hasWeight = true
+		r.rawWeight = val
+		r.Weight = parseInt(val)
 	}
 	if val, ok := post["visible"]; ok {
 		r.hasVisible = true
@@ -1076,6 +1085,21 @@ func (r *PageCreate) RawDescription() string {
 // GetDescription returns casted value of  description parameter
 func (r *PageCreate) GetDescription() string {
 	return r.Description
+}
+
+// HasWeight returns true if weight was set
+func (r *PageCreate) HasWeight() bool {
+	return r.hasWeight
+}
+
+// RawWeight returns raw value of weight parameter
+func (r *PageCreate) RawWeight() string {
+	return r.rawWeight
+}
+
+// GetWeight returns casted value of  weight parameter
+func (r *PageCreate) GetWeight() int {
+	return r.Weight
 }
 
 // HasVisible returns true if visible was set


### PR DESCRIPTION
Now when a page is created, a weight property can be set.
This way we can control where the page will show up in the page tree upon creation.
