### PR TITLE
Fix number sanitizer bug

### DIFF
--- a/compose/service/values/sanitizer.go
+++ b/compose/service/values/sanitizer.go
@@ -219,6 +219,7 @@ func (sanitizer) sNumber(v *types.RecordValue, f *types.ModuleField, m *types.Mo
 	// In case of fractures, remove trailing 0's
 	if strings.Contains(v.Value, ".") {
 		v.Value = strings.TrimRight(v.Value, "0")
+		v.Value = strings.TrimRight(v.Value, ".")
 	}
 
 	return v

--- a/compose/service/values/sanitizer_test.go
+++ b/compose/service/values/sanitizer_test.go
@@ -143,6 +143,20 @@ func Test_sanitizer_Run(t *testing.T) {
 			input:   "42.4",
 			output:  "42",
 		},
+		{
+			name:    "number precision; trailing .00",
+			kind:    "Number",
+			options: map[string]interface{}{"precision": 2},
+			input:   "42.00",
+			output:  "42",
+		},
+		{
+			name:    "number precision; trailing .040",
+			kind:    "Number",
+			options: map[string]interface{}{"precision": 2},
+			input:   "42.040",
+			output:  "42.04",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Number sanitizer now properly sanitizes trailing 0 with precision.
Example: 
Input: 42.00
Output: 42