### PR TITLE
Implement support for labels on modules

### DIFF
--- a/compose/rest.yaml
+++ b/compose/rest.yaml
@@ -11,6 +11,7 @@ endpoints:
   path: "/namespace"
   authentication: []
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/label
     - sqlxTypes github.com/jmoiron/sqlx/types
     - time
   apis:
@@ -31,6 +32,10 @@ endpoints:
       - type: uint
         name: limit
         title: Limit
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: string
         name: pageCursor
         title: Page cursor
@@ -47,6 +52,10 @@ endpoints:
         name: name
         required: true
         title: Name
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: string
         name: slug
         required: false
@@ -96,6 +105,10 @@ endpoints:
         name: meta
         required: true
         title: Meta data
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: "*time.Time"
         name: updatedAt
         required: false
@@ -132,6 +145,7 @@ endpoints:
   authentication: []
   imports:
     - sqlxTypes github.com/jmoiron/sqlx/types
+    - github.com/cortezaproject/corteza-server/pkg/label
   parameters:
     path:
     - type: uint64
@@ -157,6 +171,10 @@ endpoints:
         name: handle
         required: false
         title: Search by handle
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: uint
         name: limit
         title: Limit
@@ -196,6 +214,10 @@ endpoints:
         name: weight
         required: false
         title: Page tree weight
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: bool
         name: visible
         required: false
@@ -254,6 +276,10 @@ endpoints:
         name: weight
         required: false
         title: Page tree weight
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: bool
         name: visible
         required: false
@@ -331,6 +357,7 @@ endpoints:
   imports:
     - sqlxTypes github.com/jmoiron/sqlx/types
     - github.com/cortezaproject/corteza-server/compose/types
+    - github.com/cortezaproject/corteza-server/pkg/label
     - time
   apis:
   - name: list
@@ -357,6 +384,10 @@ endpoints:
       - type: string
         name: pageCursor
         title: Page cursor
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: string
         name: sort
         title: Sort items
@@ -382,6 +413,10 @@ endpoints:
         name: meta
         required: true
         title: Module meta data
+      - type: map[string]string
+        name: labels
+        title: Module labels
+        parser: label.ParseStrings
   - name: read
     method: GET
     title: Read module
@@ -423,6 +458,10 @@ endpoints:
         name: updatedAt
         required: false
         title: Last update (or creation) date
+      - type: map[string]string
+        name: labels
+        title: Module labels
+        parser: label.ParseStrings
   - name: delete
     method: DELETE
     title: Delete module
@@ -454,6 +493,7 @@ endpoints:
   path: "/namespace/{namespaceID}/module/{moduleID}/record"
   authentication: []
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/label
     - github.com/cortezaproject/corteza-server/compose/types
   parameters:
     path:
@@ -498,6 +538,10 @@ endpoints:
         type: string
         required: false
         title: Filtering condition (same as query, deprecated)
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - name: deleted
         required: false
         title: Exclude (0, default), include (1) or return only (2) deleted records
@@ -606,6 +650,10 @@ endpoints:
         name: records
         required: false
         title: Records
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: read
     method: GET
     title: Read records by ID from module section
@@ -635,6 +683,10 @@ endpoints:
         name: records
         required: false
         title: Records
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: bulkDelete
     method: DELETE
     title: Delete record row from module section
@@ -712,6 +764,7 @@ endpoints:
   authentication: []
   imports:
     - sqlxTypes github.com/jmoiron/sqlx/types
+    - github.com/cortezaproject/corteza-server/pkg/label
     - time
   parameters:
     path:
@@ -734,6 +787,10 @@ endpoints:
         required: false
         title: Search charts by handle
         type: string
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: uint
         name: limit
         title: Limit
@@ -761,6 +818,10 @@ endpoints:
         title: Chart handle
         type: string
         required: false
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: read
     method: GET
     title: Read charts by ID
@@ -794,6 +855,10 @@ endpoints:
         title: Chart handle
         type: string
         required: false
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: "*time.Time"
         name: updatedAt
         required: false

--- a/compose/rest/chart.go
+++ b/compose/rest/chart.go
@@ -55,6 +55,7 @@ func (ctrl Chart) List(ctx context.Context, r *request.ChartList) (interface{}, 
 
 			Handle: r.Handle,
 			Query:  r.Query,
+			Labels: r.Labels,
 		}
 	)
 
@@ -76,6 +77,7 @@ func (ctrl Chart) Create(ctx context.Context, r *request.ChartCreate) (interface
 		NamespaceID: r.NamespaceID,
 		Name:        r.Name,
 		Handle:      r.Handle,
+		Labels:      r.Labels,
 	}
 
 	if len(r.Config) > 2 {
@@ -102,6 +104,7 @@ func (ctrl Chart) Update(ctx context.Context, r *request.ChartUpdate) (interface
 			Handle:      r.Handle,
 			NamespaceID: r.NamespaceID,
 			UpdatedAt:   r.UpdatedAt,
+			Labels:      r.Labels,
 		}
 	)
 

--- a/compose/rest/module.go
+++ b/compose/rest/module.go
@@ -80,6 +80,7 @@ func (ctrl *Module) List(ctx context.Context, r *request.ModuleList) (interface{
 			Query:       r.Query,
 			Name:        r.Name,
 			Handle:      r.Handle,
+			Labels:      r.Labels,
 		}
 	)
 
@@ -109,6 +110,7 @@ func (ctrl *Module) Create(ctx context.Context, r *request.ModuleCreate) (interf
 			Handle:      r.Handle,
 			Fields:      r.Fields,
 			Meta:        r.Meta,
+			Labels:      r.Labels,
 		}
 	)
 
@@ -126,6 +128,7 @@ func (ctrl *Module) Update(ctx context.Context, r *request.ModuleUpdate) (interf
 			Handle:      r.Handle,
 			Fields:      r.Fields,
 			Meta:        r.Meta,
+			Labels:      r.Labels,
 			UpdatedAt:   r.UpdatedAt,
 		}
 	)

--- a/compose/rest/namespace.go
+++ b/compose/rest/namespace.go
@@ -59,8 +59,9 @@ func (ctrl Namespace) List(ctx context.Context, r *request.NamespaceList) (inter
 	var (
 		err error
 		f   = types.NamespaceFilter{
-			Query: r.Query,
-			Slug:  r.Slug,
+			Query:  r.Query,
+			Slug:   r.Slug,
+			Labels: r.Labels,
 		}
 	)
 
@@ -83,6 +84,7 @@ func (ctrl Namespace) Create(ctx context.Context, r *request.NamespaceCreate) (i
 			Name:    r.Name,
 			Slug:    r.Slug,
 			Enabled: r.Enabled,
+			Labels:  r.Labels,
 		}
 	)
 
@@ -107,6 +109,7 @@ func (ctrl Namespace) Update(ctx context.Context, r *request.NamespaceUpdate) (i
 			Name:      r.Name,
 			Slug:      r.Slug,
 			Enabled:   r.Enabled,
+			Labels:    r.Labels,
 			UpdatedAt: r.UpdatedAt,
 		}
 	)

--- a/compose/rest/page.go
+++ b/compose/rest/page.go
@@ -59,6 +59,7 @@ func (ctrl *Page) List(ctx context.Context, r *request.PageList) (interface{}, e
 		f   = types.PageFilter{
 			NamespaceID: r.NamespaceID,
 			ParentID:    r.SelfID,
+			Labels:      r.Labels,
 
 			Handle: r.Handle,
 			Query:  r.Query,
@@ -94,6 +95,7 @@ func (ctrl *Page) Create(ctx context.Context, r *request.PageCreate) (interface{
 			Description: r.Description,
 			Visible:     r.Visible,
 			Weight:      r.Weight,
+			Labels:      r.Labels,
 		}
 	)
 
@@ -129,6 +131,7 @@ func (ctrl *Page) Update(ctx context.Context, r *request.PageUpdate) (interface{
 			Description: r.Description,
 			Visible:     r.Visible,
 			Weight:      r.Weight,
+			Labels:      r.Labels,
 		}
 	)
 

--- a/compose/rest/record.go
+++ b/compose/rest/record.go
@@ -81,6 +81,7 @@ func (ctrl *Record) List(ctx context.Context, r *request.RecordList) (interface{
 		f = types.RecordFilter{
 			NamespaceID: r.NamespaceID,
 			ModuleID:    r.ModuleID,
+			Labels:      r.Labels,
 			Deleted:     filter.State(r.Deleted),
 		}
 	)
@@ -153,6 +154,7 @@ func (ctrl *Record) Create(ctx context.Context, r *request.RecordCreate) (interf
 			NamespaceID: r.NamespaceID,
 			ModuleID:    r.ModuleID,
 			Values:      r.Values,
+			Labels:      r.Labels,
 		}
 		oo = append(oo, &types.RecordBulkOperation{
 			Record:    rr,
@@ -201,6 +203,7 @@ func (ctrl *Record) Update(ctx context.Context, r *request.RecordUpdate) (interf
 			NamespaceID: r.NamespaceID,
 			ModuleID:    r.ModuleID,
 			Values:      r.Values,
+			Labels:      r.Labels,
 		}
 		oo = append(oo, &types.RecordBulkOperation{
 			Record:    rr,

--- a/compose/rest/request/chart.go
+++ b/compose/rest/request/chart.go
@@ -11,6 +11,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
@@ -46,6 +47,11 @@ type (
 		//
 		// Search charts by handle
 		Handle string
+
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
 
 		// Limit GET parameter
 		//
@@ -83,6 +89,11 @@ type (
 		//
 		// Chart handle
 		Handle string
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	ChartRead struct {
@@ -123,6 +134,11 @@ type (
 		// Chart handle
 		Handle string
 
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
+
 		// UpdatedAt POST parameter
 		//
 		// Last update (or creation) date
@@ -153,6 +169,7 @@ func (r ChartList) Auditable() map[string]interface{} {
 		"namespaceID": r.NamespaceID,
 		"query":       r.Query,
 		"handle":      r.Handle,
+		"labels":      r.Labels,
 		"limit":       r.Limit,
 		"pageCursor":  r.PageCursor,
 		"sort":        r.Sort,
@@ -172,6 +189,11 @@ func (r ChartList) GetQuery() string {
 // Auditable returns all auditable/loggable parameters
 func (r ChartList) GetHandle() string {
 	return r.Handle
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -214,6 +236,17 @@ func (r *ChartList) Fill(req *http.Request) (err error) {
 		}
 		if val, ok := tmp["handle"]; ok && len(val) > 0 {
 			r.Handle, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -265,6 +298,7 @@ func (r ChartCreate) Auditable() map[string]interface{} {
 		"config":      r.Config,
 		"name":        r.Name,
 		"handle":      r.Handle,
+		"labels":      r.Labels,
 	}
 }
 
@@ -286,6 +320,11 @@ func (r ChartCreate) GetName() string {
 // Auditable returns all auditable/loggable parameters
 func (r ChartCreate) GetHandle() string {
 	return r.Handle
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -324,6 +363,18 @@ func (r *ChartCreate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["handle"]; ok && len(val) > 0 {
 			r.Handle, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -415,6 +466,7 @@ func (r ChartUpdate) Auditable() map[string]interface{} {
 		"config":      r.Config,
 		"name":        r.Name,
 		"handle":      r.Handle,
+		"labels":      r.Labels,
 		"updatedAt":   r.UpdatedAt,
 	}
 }
@@ -442,6 +494,11 @@ func (r ChartUpdate) GetName() string {
 // Auditable returns all auditable/loggable parameters
 func (r ChartUpdate) GetHandle() string {
 	return r.Handle
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -485,6 +542,18 @@ func (r *ChartUpdate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["handle"]; ok && len(val) > 0 {
 			r.Handle, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}

--- a/compose/rest/request/module.go
+++ b/compose/rest/request/module.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/cortezaproject/corteza-server/compose/types"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
@@ -63,6 +64,11 @@ type (
 		// Page cursor
 		PageCursor string
 
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
+
 		// Sort GET parameter
 		//
 		// Sort items
@@ -94,6 +100,11 @@ type (
 		//
 		// Module meta data
 		Meta sqlxTypes.JSONText
+
+		// Labels POST parameter
+		//
+		// Module labels
+		Labels map[string]string
 	}
 
 	ModuleRead struct {
@@ -143,6 +154,11 @@ type (
 		//
 		// Last update (or creation) date
 		UpdatedAt *time.Time
+
+		// Labels POST parameter
+		//
+		// Module labels
+		Labels map[string]string
 	}
 
 	ModuleDelete struct {
@@ -189,6 +205,7 @@ func (r ModuleList) Auditable() map[string]interface{} {
 		"handle":      r.Handle,
 		"limit":       r.Limit,
 		"pageCursor":  r.PageCursor,
+		"labels":      r.Labels,
 		"sort":        r.Sort,
 	}
 }
@@ -221,6 +238,11 @@ func (r ModuleList) GetLimit() uint {
 // Auditable returns all auditable/loggable parameters
 func (r ModuleList) GetPageCursor() string {
 	return r.PageCursor
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ModuleList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -275,6 +297,17 @@ func (r *ModuleList) Fill(req *http.Request) (err error) {
 				return err
 			}
 		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 		if val, ok := tmp["sort"]; ok && len(val) > 0 {
 			r.Sort, err = val[0], nil
 			if err != nil {
@@ -311,6 +344,7 @@ func (r ModuleCreate) Auditable() map[string]interface{} {
 		"handle":      r.Handle,
 		"fields":      r.Fields,
 		"meta":        r.Meta,
+		"labels":      r.Labels,
 	}
 }
 
@@ -337,6 +371,11 @@ func (r ModuleCreate) GetFields() types.ModuleFieldSet {
 // Auditable returns all auditable/loggable parameters
 func (r ModuleCreate) GetMeta() sqlxTypes.JSONText {
 	return r.Meta
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ModuleCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -382,6 +421,18 @@ func (r *ModuleCreate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["meta"]; ok && len(val) > 0 {
 			r.Meta, err = payload.ParseJSONTextWithErr(val[0])
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -475,6 +526,7 @@ func (r ModuleUpdate) Auditable() map[string]interface{} {
 		"fields":      r.Fields,
 		"meta":        r.Meta,
 		"updatedAt":   r.UpdatedAt,
+		"labels":      r.Labels,
 	}
 }
 
@@ -511,6 +563,11 @@ func (r ModuleUpdate) GetMeta() sqlxTypes.JSONText {
 // Auditable returns all auditable/loggable parameters
 func (r ModuleUpdate) GetUpdatedAt() *time.Time {
 	return r.UpdatedAt
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ModuleUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -563,6 +620,18 @@ func (r *ModuleUpdate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["updatedAt"]; ok && len(val) > 0 {
 			r.UpdatedAt, err = payload.ParseISODatePtrWithErr(val[0])
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}

--- a/compose/rest/request/namespace.go
+++ b/compose/rest/request/namespace.go
@@ -11,6 +11,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
@@ -47,6 +48,11 @@ type (
 		// Limit
 		Limit uint
 
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
+
 		// PageCursor GET parameter
 		//
 		// Page cursor
@@ -63,6 +69,11 @@ type (
 		//
 		// Name
 		Name string
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 
 		// Slug POST parameter
 		//
@@ -113,6 +124,11 @@ type (
 		// Meta data
 		Meta sqlxTypes.JSONText
 
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
+
 		// UpdatedAt POST parameter
 		//
 		// Last update (or creation) date
@@ -150,6 +166,7 @@ func (r NamespaceList) Auditable() map[string]interface{} {
 		"query":      r.Query,
 		"slug":       r.Slug,
 		"limit":      r.Limit,
+		"labels":     r.Labels,
 		"pageCursor": r.PageCursor,
 		"sort":       r.Sort,
 	}
@@ -168,6 +185,11 @@ func (r NamespaceList) GetSlug() string {
 // Auditable returns all auditable/loggable parameters
 func (r NamespaceList) GetLimit() uint {
 	return r.Limit
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r NamespaceList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -215,6 +237,17 @@ func (r *NamespaceList) Fill(req *http.Request) (err error) {
 				return err
 			}
 		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 		if val, ok := tmp["pageCursor"]; ok && len(val) > 0 {
 			r.PageCursor, err = val[0], nil
 			if err != nil {
@@ -241,6 +274,7 @@ func NewNamespaceCreate() *NamespaceCreate {
 func (r NamespaceCreate) Auditable() map[string]interface{} {
 	return map[string]interface{}{
 		"name":    r.Name,
+		"labels":  r.Labels,
 		"slug":    r.Slug,
 		"enabled": r.Enabled,
 		"meta":    r.Meta,
@@ -250,6 +284,11 @@ func (r NamespaceCreate) Auditable() map[string]interface{} {
 // Auditable returns all auditable/loggable parameters
 func (r NamespaceCreate) GetName() string {
 	return r.Name
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r NamespaceCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -289,6 +328,18 @@ func (r *NamespaceCreate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["name"]; ok && len(val) > 0 {
 			r.Name, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -377,6 +428,7 @@ func (r NamespaceUpdate) Auditable() map[string]interface{} {
 		"slug":        r.Slug,
 		"enabled":     r.Enabled,
 		"meta":        r.Meta,
+		"labels":      r.Labels,
 		"updatedAt":   r.UpdatedAt,
 	}
 }
@@ -404,6 +456,11 @@ func (r NamespaceUpdate) GetEnabled() bool {
 // Auditable returns all auditable/loggable parameters
 func (r NamespaceUpdate) GetMeta() sqlxTypes.JSONText {
 	return r.Meta
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r NamespaceUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -454,6 +511,18 @@ func (r *NamespaceUpdate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["meta"]; ok && len(val) > 0 {
 			r.Meta, err = payload.ParseJSONTextWithErr(val[0])
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}

--- a/compose/rest/request/page.go
+++ b/compose/rest/request/page.go
@@ -11,6 +11,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
@@ -50,6 +51,11 @@ type (
 		//
 		// Search by handle
 		Handle string
+
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
 
 		// Limit GET parameter
 		//
@@ -102,6 +108,11 @@ type (
 		//
 		// Page tree weight
 		Weight int
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 
 		// Visible POST parameter
 		//
@@ -173,6 +184,11 @@ type (
 		//
 		// Page tree weight
 		Weight int
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 
 		// Visible POST parameter
 		//
@@ -261,6 +277,7 @@ func (r PageList) Auditable() map[string]interface{} {
 		"selfID":      r.SelfID,
 		"query":       r.Query,
 		"handle":      r.Handle,
+		"labels":      r.Labels,
 		"limit":       r.Limit,
 		"pageCursor":  r.PageCursor,
 		"sort":        r.Sort,
@@ -285,6 +302,11 @@ func (r PageList) GetQuery() string {
 // Auditable returns all auditable/loggable parameters
 func (r PageList) GetHandle() string {
 	return r.Handle
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r PageList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -333,6 +355,17 @@ func (r *PageList) Fill(req *http.Request) (err error) {
 		}
 		if val, ok := tmp["handle"]; ok && len(val) > 0 {
 			r.Handle, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -387,6 +420,7 @@ func (r PageCreate) Auditable() map[string]interface{} {
 		"handle":      r.Handle,
 		"description": r.Description,
 		"weight":      r.Weight,
+		"labels":      r.Labels,
 		"visible":     r.Visible,
 		"blocks":      r.Blocks,
 	}
@@ -425,6 +459,11 @@ func (r PageCreate) GetDescription() string {
 // Auditable returns all auditable/loggable parameters
 func (r PageCreate) GetWeight() int {
 	return r.Weight
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r PageCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -494,6 +533,18 @@ func (r *PageCreate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["weight"]; ok && len(val) > 0 {
 			r.Weight, err = payload.ParseInt(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -647,6 +698,7 @@ func (r PageUpdate) Auditable() map[string]interface{} {
 		"handle":      r.Handle,
 		"description": r.Description,
 		"weight":      r.Weight,
+		"labels":      r.Labels,
 		"visible":     r.Visible,
 		"blocks":      r.Blocks,
 	}
@@ -690,6 +742,11 @@ func (r PageUpdate) GetDescription() string {
 // Auditable returns all auditable/loggable parameters
 func (r PageUpdate) GetWeight() int {
 	return r.Weight
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r PageUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -759,6 +816,18 @@ func (r *PageUpdate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["weight"]; ok && len(val) > 0 {
 			r.Weight, err = payload.ParseInt(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}

--- a/compose/rest/request/record.go
+++ b/compose/rest/request/record.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/cortezaproject/corteza-server/compose/types"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi"
 	"io"
@@ -77,6 +78,11 @@ type (
 		//
 		// Filtering condition (same as query, deprecated)
 		Filter string
+
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
 
 		// Deleted GET parameter
 		//
@@ -239,6 +245,11 @@ type (
 		//
 		// Records
 		Records types.RecordBulkSet
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	RecordRead struct {
@@ -283,6 +294,11 @@ type (
 		//
 		// Records
 		Records types.RecordBulkSet
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	RecordBulkDelete struct {
@@ -507,6 +523,7 @@ func (r RecordList) Auditable() map[string]interface{} {
 		"moduleID":    r.ModuleID,
 		"query":       r.Query,
 		"filter":      r.Filter,
+		"labels":      r.Labels,
 		"deleted":     r.Deleted,
 		"limit":       r.Limit,
 		"pageCursor":  r.PageCursor,
@@ -532,6 +549,11 @@ func (r RecordList) GetQuery() string {
 // Auditable returns all auditable/loggable parameters
 func (r RecordList) GetFilter() string {
 	return r.Filter
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RecordList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -579,6 +601,17 @@ func (r *RecordList) Fill(req *http.Request) (err error) {
 		}
 		if val, ok := tmp["filter"]; ok && len(val) > 0 {
 			r.Filter, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}
@@ -1108,6 +1141,7 @@ func (r RecordCreate) Auditable() map[string]interface{} {
 		"moduleID":    r.ModuleID,
 		"values":      r.Values,
 		"records":     r.Records,
+		"labels":      r.Labels,
 	}
 }
 
@@ -1129,6 +1163,11 @@ func (r RecordCreate) GetValues() types.RecordValueSet {
 // Auditable returns all auditable/loggable parameters
 func (r RecordCreate) GetRecords() types.RecordBulkSet {
 	return r.Records
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RecordCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -1164,6 +1203,18 @@ func (r *RecordCreate) Fill(req *http.Request) (err error) {
 		//        return err
 		//    }
 		//}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	{
@@ -1269,6 +1320,7 @@ func (r RecordUpdate) Auditable() map[string]interface{} {
 		"recordID":    r.RecordID,
 		"values":      r.Values,
 		"records":     r.Records,
+		"labels":      r.Labels,
 	}
 }
 
@@ -1295,6 +1347,11 @@ func (r RecordUpdate) GetValues() types.RecordValueSet {
 // Auditable returns all auditable/loggable parameters
 func (r RecordUpdate) GetRecords() types.RecordBulkSet {
 	return r.Records
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RecordUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -1330,6 +1387,18 @@ func (r *RecordUpdate) Fill(req *http.Request) (err error) {
 		//        return err
 		//    }
 		//}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	{

--- a/compose/service/chart.go
+++ b/compose/service/chart.go
@@ -6,7 +6,9 @@ import (
 	"github.com/cortezaproject/corteza-server/compose/types"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
 	"github.com/cortezaproject/corteza-server/pkg/handle"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/store"
+	"reflect"
 )
 
 type (
@@ -37,7 +39,15 @@ type (
 		DeleteByID(namespaceID, chartID uint64) error
 	}
 
-	chartUpdateHandler func(ctx context.Context, ns *types.Namespace, c *types.Chart) (bool, error)
+	chartUpdateHandler func(ctx context.Context, ns *types.Namespace, c *types.Chart) (chartChanges, error)
+
+	chartChanges uint8
+)
+
+const (
+	chartUnchanged     chartChanges = 0
+	chartChanged       chartChanges = 1
+	chartLabelsChanged chartChanges = 2
 )
 
 func Chart() ChartService {
@@ -77,7 +87,25 @@ func (svc chart) Find(filter types.ChartFilter) (set types.ChartSet, f types.Cha
 			aProps.setNamespace(ns)
 		}
 
+		if len(filter.Labels) > 0 {
+			filter.LabeledIDs, err = label.Search(
+				svc.ctx,
+				svc.store,
+				types.Chart{}.LabelResourceKind(),
+				filter.Labels,
+				filter.ChartID...,
+			)
+
+			if err != nil {
+				return err
+			}
+		}
+
 		if set, f, err = store.SearchComposeCharts(svc.ctx, svc.store, filter); err != nil {
+			return err
+		}
+
+		if err = label.Load(svc.ctx, svc.store, toLabeledCharts(set)...); err != nil {
 			return err
 		}
 
@@ -116,19 +144,23 @@ func (svc chart) Create(new *types.Chart) (*types.Chart, error) {
 		aProps = &chartActionProps{changed: new}
 	)
 
-	err = func() error {
+	err = store.Tx(svc.ctx, svc.store, func(ctx context.Context, s store.Storer) (err error) {
 		if !handle.IsValid(new.Handle) {
 			return ChartErrInvalidHandle()
 		}
 
-		if ns, err = loadNamespace(svc.ctx, svc.store, new.NamespaceID); err != nil {
+		if ns, err = loadNamespace(ctx, s, new.NamespaceID); err != nil {
 			return err
 		}
 
 		aProps.setNamespace(ns)
 
-		if !svc.ac.CanCreateChart(svc.ctx, ns) {
+		if !svc.ac.CanCreateChart(ctx, ns) {
 			return ChartErrNotAllowedToCreate()
+		}
+
+		if err = svc.uniqueCheck(new); err != nil {
+			return err
 		}
 
 		new.ID = nextID()
@@ -136,12 +168,16 @@ func (svc chart) Create(new *types.Chart) (*types.Chart, error) {
 		new.UpdatedAt = nil
 		new.DeletedAt = nil
 
-		if err = svc.uniqueCheck(new); err != nil {
+		if err = store.CreateComposeChart(ctx, s, new); err != nil {
 			return err
 		}
 
-		return store.CreateComposeChart(svc.ctx, svc.store, new)
-	}()
+		if err = label.Create(ctx, s, new); err != nil {
+			return
+		}
+
+		return nil
+	})
 
 	return new, svc.recordAction(svc.ctx, aProps, ChartActionCreate, err)
 }
@@ -181,6 +217,10 @@ func (svc chart) lookup(namespaceID uint64, lookup func(*chartActionProps) (*typ
 			return ChartErrNotAllowedToRead()
 		}
 
+		if err = label.Load(svc.ctx, svc.store, c); err != nil {
+			return err
+		}
+
 		return nil
 	}()
 
@@ -189,7 +229,7 @@ func (svc chart) lookup(namespaceID uint64, lookup func(*chartActionProps) (*typ
 
 func (svc chart) updater(namespaceID, chartID uint64, action func(...*chartActionProps) *chartAction, fn chartUpdateHandler) (*types.Chart, error) {
 	var (
-		changed bool
+		changes chartChanges
 		ns      *types.Namespace
 		c       *types.Chart
 		aProps  = &chartActionProps{chart: &types.Chart{ID: chartID, NamespaceID: namespaceID}}
@@ -202,16 +242,30 @@ func (svc chart) updater(namespaceID, chartID uint64, action func(...*chartActio
 			return
 		}
 
+		if err = label.Load(svc.ctx, svc.store, c); err != nil {
+			return err
+		}
+
 		aProps.setNamespace(ns)
 		aProps.setChanged(c)
 
-		if changed, err = fn(ctx, ns, c); err != nil {
+		if changes, err = fn(ctx, ns, c); err != nil {
 			return err
-		} else if !changed {
-			return
 		}
 
-		return store.UpdateComposeChart(ctx, s, c)
+		if changes&chartChanged > 0 {
+			if err = store.UpdateComposeChart(ctx, s, c); err != nil {
+				return err
+			}
+		}
+
+		if changes&chartLabelsChanged > 0 {
+			if err = label.Update(ctx, s, c); err != nil {
+				return
+			}
+		}
+
+		return nil
 	})
 
 	return c, svc.recordAction(svc.ctx, aProps, action, err)
@@ -228,57 +282,79 @@ func (svc chart) uniqueCheck(c *types.Chart) (err error) {
 }
 
 func (svc chart) handleUpdate(upd *types.Chart) chartUpdateHandler {
-	return func(ctx context.Context, ns *types.Namespace, c *types.Chart) (bool, error) {
-		if isStale(upd.UpdatedAt, c.UpdatedAt, c.CreatedAt) {
-			return false, ChartErrStaleData()
+	return func(ctx context.Context, ns *types.Namespace, res *types.Chart) (changes chartChanges, err error) {
+		if isStale(upd.UpdatedAt, res.UpdatedAt, res.CreatedAt) {
+			return chartUnchanged, ChartErrStaleData()
 		}
 
-		if upd.Handle != c.Handle && !handle.IsValid(upd.Handle) {
-			return false, ChartErrInvalidHandle()
+		if upd.Handle != res.Handle && !handle.IsValid(upd.Handle) {
+			return chartUnchanged, ChartErrInvalidHandle()
 		}
 
 		if err := svc.uniqueCheck(upd); err != nil {
-			return false, err
+			return chartUnchanged, err
 		}
 
-		if !svc.ac.CanUpdateChart(svc.ctx, c) {
-			return false, ChartErrNotAllowedToUpdate()
+		if !svc.ac.CanUpdateChart(svc.ctx, res) {
+			return chartUnchanged, ChartErrNotAllowedToUpdate()
 		}
 
-		c.Name = upd.Name
-		c.Handle = upd.Handle
-		c.Config = upd.Config
-		c.UpdatedAt = now()
-		return true, nil
+		if res.Name != upd.Name {
+			changes |= chartChanged
+			res.Name = upd.Name
+		}
+
+		if res.Handle != upd.Handle {
+			changes |= chartChanged
+			res.Handle = upd.Handle
+		}
+
+		if !reflect.DeepEqual(upd.Config, res.Config) {
+			changes |= chartChanged
+			res.Config = upd.Config
+		}
+
+		if changes&chartChanged > 0 {
+			res.UpdatedAt = now()
+		}
+
+		if upd.Labels != nil {
+			if label.Changed(res.Labels, upd.Labels) {
+				changes |= chartLabelsChanged
+				res.Labels = upd.Labels
+			}
+		}
+
+		return
 	}
 }
 
-func (svc chart) handleDelete(ctx context.Context, ns *types.Namespace, c *types.Chart) (bool, error) {
+func (svc chart) handleDelete(ctx context.Context, ns *types.Namespace, c *types.Chart) (chartChanges, error) {
 	if !svc.ac.CanDeleteChart(ctx, c) {
-		return false, ChartErrNotAllowedToDelete()
+		return chartUnchanged, ChartErrNotAllowedToDelete()
 	}
 
 	if c.DeletedAt != nil {
 		// chart already deleted
-		return false, nil
+		return chartUnchanged, nil
 	}
 
 	c.DeletedAt = now()
-	return true, nil
+	return chartChanged, nil
 }
 
-func (svc chart) handleUndelete(ctx context.Context, ns *types.Namespace, c *types.Chart) (bool, error) {
+func (svc chart) handleUndelete(ctx context.Context, ns *types.Namespace, c *types.Chart) (chartChanges, error) {
 	if !svc.ac.CanDeleteChart(ctx, c) {
-		return false, ChartErrNotAllowedToUndelete()
+		return chartUnchanged, ChartErrNotAllowedToUndelete()
 	}
 
 	if c.DeletedAt == nil {
 		// chart not deleted
-		return false, nil
+		return chartUnchanged, nil
 	}
 
 	c.DeletedAt = nil
-	return true, nil
+	return chartChanged, nil
 }
 
 func loadChart(ctx context.Context, s store.Storer, namespaceID, chartID uint64) (ns *types.Namespace, c *types.Chart, err error) {
@@ -302,4 +378,20 @@ func loadChart(ctx context.Context, s store.Storer, namespaceID, chartID uint64)
 	}
 
 	return
+}
+
+// toLabeledCharts converts to []label.LabeledResource
+//
+// This function is auto-generated.
+func toLabeledCharts(set []*types.Chart) []label.LabeledResource {
+	if len(set) == 0 {
+		return nil
+	}
+
+	ll := make([]label.LabeledResource, len(set))
+	for i := range set {
+		ll[i] = set[i]
+	}
+
+	return ll
 }

--- a/compose/service/module_test.go
+++ b/compose/service/module_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"github.com/cortezaproject/corteza-server/compose/types"
+	"github.com/cortezaproject/corteza-server/pkg/eventbus"
+	"github.com/cortezaproject/corteza-server/pkg/logger"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	"github.com/cortezaproject/corteza-server/store"
 	"github.com/cortezaproject/corteza-server/store/sqlite3"
@@ -14,7 +16,10 @@ import (
 
 func TestModules(t *testing.T) {
 	var (
-		ctx    = context.Background()
+		//ctx    = context.Background()
+		//s, err = sqlite3.ConnectInMemory(ctx)
+
+		ctx    = logger.ContextWithValue(context.Background(), logger.MakeDebugLogger())
 		s, err = sqlite3.ConnectInMemory(ctx)
 
 		namespaceID = nextID()
@@ -33,8 +38,8 @@ func TestModules(t *testing.T) {
 		t.Fatalf("failed to truncate compose namespaces: %v", err)
 	}
 
-	if err = s.TruncateComposeCharts(ctx); err != nil {
-		t.Fatalf("failed to truncate compose charts: %v", err)
+	if err = s.TruncateComposeModules(ctx); err != nil {
+		t.Fatalf("failed to truncate compose modules: %v", err)
 	}
 
 	ns = &types.Namespace{Name: "testing", ID: namespaceID, CreatedAt: *now()}
@@ -44,12 +49,13 @@ func TestModules(t *testing.T) {
 
 	t.Run("crud", func(t *testing.T) {
 		req := require.New(t)
-		svc := chart{
-			store: s,
-			ctx:   context.Background(),
-			ac:    AccessControl(&rbac.ServiceAllowAll{}),
+		svc := module{
+			store:    s,
+			ctx:      context.Background(),
+			ac:       AccessControl(&rbac.ServiceAllowAll{}),
+			eventbus: eventbus.New(),
 		}
-		res, err := svc.Create(&types.Chart{Name: "My first chart", NamespaceID: namespaceID})
+		res, err := svc.Create(&types.Module{Name: "My first module", NamespaceID: namespaceID})
 		req.NoError(unwrapModuleInternal(err))
 		req.NotNil(res)
 
@@ -82,7 +88,129 @@ func TestModules(t *testing.T) {
 		req.NoError(unwrapModuleInternal(err))
 		req.NotNil(res)
 		req.NotNil(res.DeletedAt)
+	})
 
+	t.Run("labels", func(t *testing.T) {
+		t.Run("search", func(t *testing.T) {
+			req := require.New(t)
+			svc := module{
+				store:    s,
+				ctx:      ctx,
+				ac:       AccessControl(&rbac.ServiceAllowAll{}),
+				eventbus: eventbus.New(),
+			}
+
+			makeModule := func(n ...string) *types.Module {
+				mod := &types.Module{
+					NamespaceID: namespaceID,
+					Name:        n[0],
+					Labels:      map[string]string{},
+				}
+
+				for i := 1; i < len(n); i += 2 {
+					mod.Labels[n[i]] = n[i+1]
+				}
+
+				out, err := svc.Create(mod)
+
+				req.NoError(unwrapModuleInternal(err))
+				return out
+			}
+
+			findModules := func(labels map[string]string, IDs []uint64) types.ModuleSet {
+				f := types.ModuleFilter{NamespaceID: namespaceID, Labels: labels, ModuleID: IDs}
+				set, _, err := svc.Find(f)
+				req.NoError(unwrapModuleInternal(err))
+
+				return set
+			}
+
+			makeModule("labeled module 1", "label1", "value1", "label2", "value2")
+			m2 := makeModule("labeled module 2", "label1", "value1")
+			m3 := makeModule("labeled module 3")
+
+			// return all -- no label/ID filter, return all
+			req.Len(findModules(nil, nil), 3)
+
+			// return 2 - both that have label1=valu1
+			req.Len(findModules(map[string]string{"label1": "value1"}, nil), 2)
+
+			// return 0 - none have foo=foo
+			req.Len(findModules(map[string]string{"foo": "foo"}, nil), 0)
+
+			// one has label2=value2
+			req.Len(findModules(map[string]string{"label2": "value2"}, nil), 1)
+
+			// explicit by ID and label
+			req.Len(findModules(map[string]string{"label1": "value1"}, []uint64{m2.ID}), 1)
+
+			// none with this combo
+			req.Len(findModules(map[string]string{"foo": "foo"}, []uint64{m3.ID}), 0)
+
+			// one with explicit ID (regression) and nil for label filter
+			req.Len(findModules(nil, []uint64{m3.ID}), 1)
+
+			// one with explicit ID (regression) and empty map for label filter
+			req.Len(findModules(map[string]string{}, []uint64{m3.ID}), 1)
+		})
+
+		t.Run("CRUD", func(t *testing.T) {
+			req := require.New(t)
+			svc := module{
+				store:    s,
+				ctx:      ctx,
+				ac:       AccessControl(&rbac.ServiceAllowAll{}),
+				eventbus: eventbus.New(),
+			}
+
+			findAndReturnLabel := func(id uint64) map[string]string {
+				res, err := svc.FindByID(namespaceID, id)
+				req.NoError(unwrapModuleInternal(err))
+				req.NotNil(res)
+				return res.Labels
+			}
+
+			// create unlabeled module
+			res, err := svc.Create(&types.Module{Name: "unLabeledIDs})
+			req.NoError(unwrapModuleInternal(err))
+			req.NotNil(res)
+			req.Nil(res.Labels)
+
+			// no labels should be present
+			req.Nil(findAndReturnLabel(res.ID))
+
+			// update the module with labels
+			res.Labels = map[string]string{"label1": "1st"}
+			res, err = svc.Update(res)
+			req.NoError(unwrapModuleInternal(err))
+			req.NotNil(res)
+			req.Contains(res.Labels, "label1")
+
+			// must contain the added label
+			req.Contains(findAndReturnLabel(res.ID), "label1")
+
+			res, err = svc.Create(&types.Module{Name: "LabeledIDs, Labels: map[string]string{"label2": "2nd"}})
+			req.NoError(unwrapModuleInternal(err))
+			req.NotNil(res)
+			req.Contains(res.Labels, "label2")
+
+			// must contain the added label
+			req.Contains(findAndReturnLabel(res.ID), "label2")
+
+			// update with Labels:nil (should keep labels intact)
+			res.Labels = nil
+			res, err = svc.Update(res)
+			req.NoError(unwrapModuleInternal(err))
+
+			req.Contains(findAndReturnLabel(res.ID), "label2")
+
+			// update with Labels:empty-map (should remove all labels)
+			res.Labels = map[string]string{}
+			res, err = svc.Update(res)
+			req.NoError(unwrapModuleInternal(err))
+
+			req.Empty(findAndReturnLabel(res.ID))
+		})
 	})
 }
 

--- a/compose/types/chart.go
+++ b/compose/types/chart.go
@@ -16,6 +16,8 @@ type (
 		Name   string      `json:"name"`
 		Config ChartConfig `json:"config"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		NamespaceID uint64 `json:"namespaceID,string"`
 
 		CreatedAt time.Time  `json:"createdAt,omitempty"`
@@ -40,9 +42,13 @@ type (
 	}
 
 	ChartFilter struct {
-		NamespaceID uint64 `json:"namespaceID,string"`
-		Handle      string `json:"handle"`
-		Query       string `json:"query"`
+		NamespaceID uint64   `json:"namespaceID,string"`
+		ChartID     []uint64 `json:"chartID"`
+		Handle      string   `json:"handle"`
+		Query       string   `json:"query"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted filter.State `json:"deleted"`
 

--- a/compose/types/module.go
+++ b/compose/types/module.go
@@ -2,11 +2,9 @@ package types
 
 import (
 	"github.com/cortezaproject/corteza-server/pkg/filter"
-	"time"
-
-	"github.com/jmoiron/sqlx/types"
-
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
+	"github.com/jmoiron/sqlx/types"
+	"time"
 )
 
 type (
@@ -17,6 +15,8 @@ type (
 		Meta   types.JSONText `json:"meta"`
 		Fields ModuleFieldSet `json:"fields"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		NamespaceID uint64 `json:"namespaceID,string"`
 
 		CreatedAt time.Time  `json:"createdAt,omitempty"`
@@ -25,10 +25,14 @@ type (
 	}
 
 	ModuleFilter struct {
-		NamespaceID uint64 `json:"namespaceID,string"`
-		Query       string `json:"query"`
-		Handle      string `json:"handle"`
-		Name        string `json:"name"`
+		ModuleID    []uint64 `json:"moduleID"`
+		NamespaceID uint64   `json:"namespaceID,string"`
+		Query       string   `json:"query"`
+		Handle      string   `json:"handle"`
+		Name        string   `json:"name"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted filter.State `json:"deleted"`
 

--- a/compose/types/module_field.go
+++ b/compose/types/module_field.go
@@ -28,6 +28,8 @@ type (
 		Multi        bool           `json:"isMulti"`
 		DefaultValue RecordValueSet `json:"defaultValue"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		CreatedAt time.Time  `json:"createdAt,omitempty"`
 		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 		DeletedAt *time.Time `json:"deletedAt,omitempty"`

--- a/compose/types/namespace.go
+++ b/compose/types/namespace.go
@@ -19,6 +19,8 @@ type (
 		Enabled bool          `json:"enabled"`
 		Meta    NamespaceMeta `json:"meta"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		CreatedAt time.Time  `json:"createdAt,omitempty"`
 		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 		DeletedAt *time.Time `json:"deletedAt,omitempty"`
@@ -28,6 +30,9 @@ type (
 		Query string `json:"query"`
 		Slug  string `json:"slug"`
 		Name  string `json:"name"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted filter.State `json:"deleted"`
 

--- a/compose/types/page.go
+++ b/compose/types/page.go
@@ -29,6 +29,8 @@ type (
 
 		Children PageSet `json:"children,omitempty"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		Visible bool `json:"visible"`
 		Weight  int  `json:"weight"`
 
@@ -58,6 +60,9 @@ type (
 		Root        bool   `json:"root,omitempty"`
 		Handle      string `json:"handle"`
 		Query       string `json:"query"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted filter.State `json:"deleted"`
 

--- a/compose/types/record.go
+++ b/compose/types/record.go
@@ -37,6 +37,8 @@ type (
 
 		Values RecordValueSet `json:"values,omitempty"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		NamespaceID uint64 `json:"namespaceID,string"`
 
 		OwnedBy   uint64     `json:"ownedBy,string"`
@@ -53,8 +55,8 @@ type (
 		NamespaceID uint64 `json:"namespaceID,string"`
 		Query       string `json:"query"`
 
-		// Preloaded set of additional modules that are used for record filtering
-		// Modules ModuleSet
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted filter.State `json:"deleted"`
 

--- a/compose/types/type_labels.gen.go
+++ b/compose/types/type_labels.gen.go
@@ -1,0 +1,153 @@
+package types
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+// compose/types/types.yaml
+
+// SetLabel adds new label to label map
+func (m *Chart) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Chart) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Chart) LabelResourceKind() string {
+	return "compose:chart"
+}
+
+// GetLabels adds new label to label map
+func (m Chart) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *Module) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Module) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Module) LabelResourceKind() string {
+	return "compose:module"
+}
+
+// GetLabels adds new label to label map
+func (m Module) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *ModuleField) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m ModuleField) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (ModuleField) LabelResourceKind() string {
+	return "compose:module:field"
+}
+
+// GetLabels adds new label to label map
+func (m ModuleField) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *Namespace) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Namespace) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Namespace) LabelResourceKind() string {
+	return "compose:namespace"
+}
+
+// GetLabels adds new label to label map
+func (m Namespace) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *Page) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Page) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Page) LabelResourceKind() string {
+	return "compose:page"
+}
+
+// GetLabels adds new label to label map
+func (m Page) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *Record) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Record) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Record) LabelResourceKind() string {
+	return "compose:record"
+}
+
+// GetLabels adds new label to label map
+func (m Record) LabelResourceID() uint64 {
+	return m.ID
+}

--- a/compose/types/types.yaml
+++ b/compose/types/types.yaml
@@ -1,10 +1,17 @@
 types:
   Namespace:
+    labelResourceType: compose:namespace
   Attachment:
   Module:
-  Page:
-  Chart:
-  Record:
+    labelResourceType: compose:module
   ModuleField:
+    labelResourceType: compose:module:field
+  Page:
+    labelResourceType: compose:page
+  Chart:
+    labelResourceType: compose:chart
+  Record:
+    labelResourceType: compose:record
   RecordValue:
     noIdField: true
+

--- a/pkg/codegen/assets/type_labels.gen.go.tpl
+++ b/pkg/codegen/assets/type_labels.gen.go.tpl
@@ -1,0 +1,38 @@
+package {{ .Package }}
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+// {{ .Source }}
+
+
+{{ range $name, $set := .Types }}
+{{ if $set.LabelResourceType }}
+// SetLabel adds new label to label map
+func (m *{{ $name }}) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m {{ $name }}) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func ({{ $name }}) LabelResourceKind() string {
+	return {{ printf "%q" $set.LabelResourceType }}
+}
+
+// GetLabels adds new label to label map
+func (m {{ $name }}) LabelResourceID() uint64 {
+	return m.ID
+}
+{{ end }}
+{{ end }}

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -1,1 +1,177 @@
 package label
+
+import (
+	"context"
+	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/handle"
+	"github.com/cortezaproject/corteza-server/pkg/label/types"
+	"github.com/cortezaproject/corteza-server/store"
+	"strings"
+)
+
+type (
+	Labels map[string]string
+
+	LabeledResource interface {
+		GetLabels() map[string]string
+		SetLabel(key string, value string)
+		LabelResourceKind() string
+		LabelResourceID() uint64
+	}
+)
+
+// Changed checks if label maps are same or different
+func Changed(old, new map[string]string) bool {
+	for k := range old {
+		if _, has := new[k]; !has {
+			return true
+		} else if new[k] != old[k] {
+			return true
+		}
+	}
+
+	for k := range new {
+		if _, has := old[k]; !has {
+			return true
+		} else if new[k] != old[k] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ParseStrings converts slice of strings with "key=val" format into
+func ParseStrings(ss []string) (map[string]string, error) {
+	if len(ss) == 0 {
+		return nil, nil
+	}
+
+	m := make(map[string]string)
+
+	for _, s := range ss {
+		kv := strings.SplitN(s, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid label format")
+		}
+
+		if !handle.IsValid(kv[0]) {
+			return nil, fmt.Errorf("invalid label key format")
+		}
+
+		m[kv[0]] = kv[1]
+	}
+
+	return m, nil
+}
+
+// Search queries all matching (by kind and key-value filter) labels
+//
+// In case when list of (base) resources is given, labels are also filtered by resource IDs
+// to ensure only matching subset is returned
+//
+// 3 scenarios:
+// - empty filter
+// - filter set
+// - filter & base set
+func Search(ctx context.Context, s store.Labels, kind string, f map[string]string, base ...uint64) ([]uint64, error) {
+	// label filter not set,
+	// return base resource IDs as-is
+	if len(f) == 0 {
+		return base, nil
+	}
+
+	// search for filters
+	set, _, err := store.SearchLabels(ctx, s, types.LabelFilter{Kind: kind, Filter: f, ResourceID: base})
+	if err != nil {
+		return nil, err
+	}
+
+	// If we have slice with base IDs, calculate intersection between it and fetched resourceIDs
+	// from the labels to ensure we only return results that satisfy BOTH conditions
+	return set.ResourceIDs(), nil
+}
+
+// Load searches labels for all labeled resources
+func Load(ctx context.Context, s store.Labels, rr ...LabeledResource) error {
+	if len(rr) == 0 {
+		return nil
+	}
+
+	var (
+		f = types.LabelFilter{ResourceID: make([]uint64, 0, len(rr))}
+	)
+
+	for _, r := range rr {
+		if f.Kind == "" {
+			f.Kind = r.LabelResourceKind()
+		} else if f.Kind != r.LabelResourceKind() {
+			return fmt.Errorf("expecting one label type, got two: %q, %q", f.Kind, r.LabelResourceKind())
+		}
+
+		f.ResourceID = append(f.ResourceID, r.LabelResourceID())
+	}
+
+	set, _, err := store.SearchLabels(ctx, s, f)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range rr {
+		for k, v := range set.FilterByResource(r.LabelResourceKind(), r.LabelResourceID()) {
+			r.SetLabel(k, v)
+		}
+	}
+
+	return nil
+}
+
+// Update updates/creates all labels on labeled resource and removes that are explicitly passed
+func Create(ctx context.Context, s store.Labels, r LabeledResource) error {
+	var (
+		err error
+		l   = &types.Label{
+			Kind:       r.LabelResourceKind(),
+			ResourceID: r.LabelResourceID(),
+		}
+	)
+
+	for l.Name, l.Value = range r.GetLabels() {
+		if err = store.CreateLabel(ctx, s, l); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Update updates or creates all labels on labeled resource and removes all non explicitly defined
+func Update(ctx context.Context, s store.Labels, r LabeledResource) error {
+	var (
+		err    error
+		labels = r.GetLabels()
+		keys   = make([]string, 0, len(labels))
+		key    string
+
+		l = &types.Label{
+			Kind:       r.LabelResourceKind(),
+			ResourceID: r.LabelResourceID(),
+		}
+	)
+
+	for key = range labels {
+		keys = append(keys, key)
+	}
+
+	if err = store.DeleteExtraLabels(ctx, s, r.LabelResourceKind(), r.LabelResourceID(), keys...); err != nil {
+		return err
+	}
+
+	for l.Name, l.Value = range r.GetLabels() {
+		if err = store.UpsertLabel(ctx, s, l); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/label/label_test.go
+++ b/pkg/label/label_test.go
@@ -1,1 +1,57 @@
 package label
+
+import "testing"
+
+func TestChanged(t *testing.T) {
+	tests := []struct {
+		name string
+		old  map[string]string
+		new  map[string]string
+		want bool
+	}{
+		// TODO: Add test cases.
+		{
+			"2x nil",
+			nil,
+			nil,
+			false,
+		},
+		{
+			"2x empty",
+			map[string]string{},
+			map[string]string{},
+			false,
+		},
+		{
+			"nil & empty",
+			nil,
+			map[string]string{},
+			false,
+		},
+		{
+			"same",
+			map[string]string{"a": "a"},
+			map[string]string{"a": "a"},
+			false,
+		},
+		{
+			"diff1",
+			map[string]string{"a": "a"},
+			map[string]string{"a": "b"},
+			true,
+		},
+		{
+			"diff2",
+			map[string]string{"a": "b"},
+			map[string]string{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Changed(tt.old, tt.new); got != tt.want {
+				t.Errorf("Changed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/label/types/type.go
+++ b/pkg/label/types/type.go
@@ -1,0 +1,40 @@
+package types
+
+type (
+	Label struct {
+		// Kind of the labeled resource
+		Kind string
+
+		// ID of the labeled resource
+		ResourceID uint64
+
+		Name  string
+		Value string
+	}
+
+	LabelFilter struct {
+		Kind       string
+		ResourceID []uint64
+		Filter     map[string]string
+	}
+)
+
+func (set LabelSet) ResourceIDs() (rr []uint64) {
+	rr = make([]uint64, len(set))
+	for r := range set {
+		rr[r] = set[r].ResourceID
+	}
+
+	return
+}
+
+func (set LabelSet) FilterByResource(kind string, ID uint64) map[string]string {
+	var kv = make(map[string]string)
+	for _, label := range set {
+		if kind == label.Kind && ID == label.ResourceID {
+			kv[label.Name] = label.Value
+		}
+	}
+
+	return kv
+}

--- a/pkg/label/types/type_set.gen.go
+++ b/pkg/label/types/type_set.gen.go
@@ -1,0 +1,49 @@
+package types
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+// pkg/label/types.yaml
+
+type (
+
+	// LabelSet slice of Label
+	//
+	// This type is auto-generated.
+	LabelSet []*Label
+
+	Map map[string]string
+)
+
+// Walk iterates through every slice item and calls w(Label) err
+//
+// This function is auto-generated.
+func (set LabelSet) Walk(w func(*Label) error) (err error) {
+	for i := range set {
+		if err = w(set[i]); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// LabelFilter iterates through every slice item, calls f(Label) (bool, err) and return filtered slice
+//
+// This function is auto-generated.
+func (set LabelSet) Filter(f func(*Label) (bool, error)) (out LabelSet, err error) {
+	var ok bool
+	out = LabelSet{}
+	for i := range set {
+		if ok, err = f(set[i]); err != nil {
+			return
+		} else if ok {
+			out = append(out, set[i])
+		}
+	}
+
+	return
+}

--- a/pkg/label/types/type_set.gen_test.go
+++ b/pkg/label/types/type_set.gen_test.go
@@ -1,0 +1,71 @@
+package types
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+// pkg/label/types.yaml
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestLabelSetWalk(t *testing.T) {
+	var (
+		value = make(LabelSet, 3)
+		req   = require.New(t)
+	)
+
+	// check walk with no errors
+	{
+		err := value.Walk(func(*Label) error {
+			return nil
+		})
+		req.NoError(err)
+	}
+
+	// check walk with error
+	req.Error(value.Walk(func(*Label) error { return fmt.Errorf("walk error") }))
+}
+
+func TestLabelSetFilter(t *testing.T) {
+	var (
+		value = make(LabelSet, 3)
+		req   = require.New(t)
+	)
+
+	// filter nothing
+	{
+		set, err := value.Filter(func(*Label) (bool, error) {
+			return true, nil
+		})
+		req.NoError(err)
+		req.Equal(len(set), len(value))
+	}
+
+	// filter one item
+	{
+		found := false
+		set, err := value.Filter(func(*Label) (bool, error) {
+			if !found {
+				found = true
+				return found, nil
+			}
+			return false, nil
+		})
+		req.NoError(err)
+		req.Len(set, 1)
+	}
+
+	// filter error
+	{
+		_, err := value.Filter(func(*Label) (bool, error) {
+			return false, fmt.Errorf("filter error")
+		})
+		req.Error(err)
+	}
+}

--- a/pkg/label/types/types.yaml
+++ b/pkg/label/types/types.yaml
@@ -1,0 +1,4 @@
+package: types
+types:
+  Label:
+    noIdField: true

--- a/store/interfaces.gen.go
+++ b/store/interfaces.gen.go
@@ -16,6 +16,7 @@ package store
 //  - store/compose_record_values.yaml
 //  - store/compose_records.yaml
 //  - store/credentials.yaml
+//  - store/labels.yaml
 //  - store/messaging_attachments.yaml
 //  - store/messaging_channel_members.yaml
 //  - store/messaging_channels.yaml
@@ -50,6 +51,7 @@ type (
 		ComposeRecordValues
 		ComposeRecords
 		Credentials
+		Labels
 		MessagingAttachments
 		MessagingChannelMembers
 		MessagingChannels

--- a/store/labels.gen.go
+++ b/store/labels.gen.go
@@ -1,0 +1,84 @@
+package store
+
+// This file is auto-generated.
+//
+// Template:    pkg/codegen/assets/store_base.gen.go.tpl
+// Definitions: store/labels.yaml
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/label/types"
+)
+
+type (
+	Labels interface {
+		SearchLabels(ctx context.Context, f types.LabelFilter) (types.LabelSet, types.LabelFilter, error)
+		LookupLabelByKindResourceIDName(ctx context.Context, kind string, resource_id uint64, name string) (*types.Label, error)
+
+		CreateLabel(ctx context.Context, rr ...*types.Label) error
+
+		UpdateLabel(ctx context.Context, rr ...*types.Label) error
+
+		UpsertLabel(ctx context.Context, rr ...*types.Label) error
+
+		DeleteLabel(ctx context.Context, rr ...*types.Label) error
+		DeleteLabelByKindResourceIDName(ctx context.Context, kind string, resourceID uint64, name string) error
+
+		TruncateLabels(ctx context.Context) error
+
+		// Additional custom functions
+
+		// DeleteExtraLabels (custom function)
+		DeleteExtraLabels(ctx context.Context, _kind string, _resourceID uint64, _names ...string) error
+	}
+)
+
+var _ *types.Label
+var _ context.Context
+
+// SearchLabels returns all matching Labels from store
+func SearchLabels(ctx context.Context, s Labels, f types.LabelFilter) (types.LabelSet, types.LabelFilter, error) {
+	return s.SearchLabels(ctx, f)
+}
+
+// LookupLabelByKindResourceIDName Label lookup by kind, resource, name
+func LookupLabelByKindResourceIDName(ctx context.Context, s Labels, kind string, resource_id uint64, name string) (*types.Label, error) {
+	return s.LookupLabelByKindResourceIDName(ctx, kind, resource_id, name)
+}
+
+// CreateLabel creates one or more Labels in store
+func CreateLabel(ctx context.Context, s Labels, rr ...*types.Label) error {
+	return s.CreateLabel(ctx, rr...)
+}
+
+// UpdateLabel updates one or more (existing) Labels in store
+func UpdateLabel(ctx context.Context, s Labels, rr ...*types.Label) error {
+	return s.UpdateLabel(ctx, rr...)
+}
+
+// UpsertLabel creates new or updates existing one or more Labels in store
+func UpsertLabel(ctx context.Context, s Labels, rr ...*types.Label) error {
+	return s.UpsertLabel(ctx, rr...)
+}
+
+// DeleteLabel Deletes one or more Labels from store
+func DeleteLabel(ctx context.Context, s Labels, rr ...*types.Label) error {
+	return s.DeleteLabel(ctx, rr...)
+}
+
+// DeleteLabelByKindResourceIDName Deletes Label from store
+func DeleteLabelByKindResourceIDName(ctx context.Context, s Labels, kind string, resourceID uint64, name string) error {
+	return s.DeleteLabelByKindResourceIDName(ctx, kind, resourceID, name)
+}
+
+// TruncateLabels Deletes all Labels from store
+func TruncateLabels(ctx context.Context, s Labels) error {
+	return s.TruncateLabels(ctx)
+}
+
+func DeleteExtraLabels(ctx context.Context, s Labels, _kind string, _resourceID uint64, _names ...string) error {
+	return s.DeleteExtraLabels(ctx, _kind, _resourceID, _names...)
+}

--- a/store/labels.yaml
+++ b/store/labels.yaml
@@ -1,0 +1,39 @@
+import:
+  - github.com/cortezaproject/corteza-server/pkg/label/types
+
+types:
+  type: types.Label
+
+fields:
+  - { field: Kind,       isPrimaryKey: true }
+  - { field: ResourceID, isPrimaryKey: true }
+  - { field: Name,       isPrimaryKey: true, lookupFilterPreprocessor: lower }
+  - { field: Value }
+
+lookups:
+  - fields: [ Kind, ResourceID, Name ]
+    uniqueConstraintCheck: true
+    description: |-
+      Label lookup by kind, resource, name
+
+functions:
+  - name: DeleteExtraLabels
+    arguments:
+      - { name: kind,        type: string }
+      - { name: resourceID,  type: uint64 }
+      - { name: names,        type: ...string }
+    return: [ error ]
+
+
+search:
+  enablePaging: false
+  enableSorting: false
+  enableFilterCheckFunction: false
+
+upsert:
+  enable: true
+
+rdbms:
+  alias: lbl
+  table: labels
+  customFilterConverter: true

--- a/store/rdbms/applications.go
+++ b/store/rdbms/applications.go
@@ -12,6 +12,10 @@ func (s Store) convertApplicationFilter(f types.ApplicationFilter) (query squirr
 
 	query = filter.StateCondition(query, "app.deleted_at", f.Deleted)
 
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"app.id": f.LabeledIDs})
+	}
+
 	if f.Query != "" {
 		qs := f.Query + "%"
 		query = query.Where(squirrel.Or{

--- a/store/rdbms/compose_charts.go
+++ b/store/rdbms/compose_charts.go
@@ -12,6 +12,14 @@ func (s Store) convertComposeChartFilter(f types.ChartFilter) (query squirrel.Se
 
 	query = filter.StateCondition(query, "cch.deleted_at", f.Deleted)
 
+	if len(f.ChartID) > 0 {
+		query = query.Where(squirrel.Eq{"cch.id": f.ChartID})
+	}
+
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"cch.id": f.LabeledIDs})
+	}
+
 	if f.NamespaceID > 0 {
 		query = query.Where("cch.rel_namespace = ?", f.NamespaceID)
 	}

--- a/store/rdbms/compose_modules.go
+++ b/store/rdbms/compose_modules.go
@@ -12,6 +12,14 @@ func (s Store) convertComposeModuleFilter(f types.ModuleFilter) (query squirrel.
 
 	query = filter.StateCondition(query, "cmd.deleted_at", f.Deleted)
 
+	if len(f.ModuleID) > 0 {
+		query = query.Where(squirrel.Eq{"cmd.id": f.ModuleID})
+	}
+
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"cmd.id": f.LabeledIDs})
+	}
+
 	if f.NamespaceID > 0 {
 		query = query.Where("cmd.rel_namespace = ?", f.NamespaceID)
 	}

--- a/store/rdbms/compose_namespaces.go
+++ b/store/rdbms/compose_namespaces.go
@@ -12,6 +12,10 @@ func (s Store) convertComposeNamespaceFilter(f types.NamespaceFilter) (query squ
 
 	query = filter.StateCondition(query, "cns.deleted_at", f.Deleted)
 
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"cns.id": f.LabeledIDs})
+	}
+
 	if f.Query != "" {
 		q := "%" + strings.ToLower(f.Query) + "%"
 		query = query.Where(squirrel.Or{

--- a/store/rdbms/compose_pages.go
+++ b/store/rdbms/compose_pages.go
@@ -18,6 +18,10 @@ func (s Store) convertComposePageFilter(f types.PageFilter) (query squirrel.Sele
 		query = query.Where("cpg.rel_namespace = ?", f.NamespaceID)
 	}
 
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"cpg.id": f.LabeledIDs})
+	}
+
 	if f.ParentID > 0 {
 		query = query.Where("self_id = ?", f.ParentID)
 	} else if f.Root {

--- a/store/rdbms/compose_records.go
+++ b/store/rdbms/compose_records.go
@@ -247,6 +247,10 @@ func (s Store) convertComposeRecordFilter(m *types.Module, f types.RecordFilter)
 	// Inc/exclude deleted records according to filter settings
 	query = filter.StateCondition(query, "crd.deleted_at", f.Deleted)
 
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"crd.id": f.LabeledIDs})
+	}
+
 	// Parse filters.
 	if f.Query != "" {
 		var (

--- a/store/rdbms/labels.gen.go
+++ b/store/rdbms/labels.gen.go
@@ -1,0 +1,344 @@
+package rdbms
+
+// This file is an auto-generated file
+//
+// Template:    pkg/codegen/assets/store_rdbms.gen.go.tpl
+// Definitions: store/labels.yaml
+//
+// Changes to this file may cause incorrect behavior
+// and will be lost if the code is regenerated.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/Masterminds/squirrel"
+	"github.com/cortezaproject/corteza-server/pkg/label/types"
+	"github.com/cortezaproject/corteza-server/store"
+)
+
+var _ = errors.Is
+
+// SearchLabels returns all matching rows
+//
+// This function calls convertLabelFilter with the given
+// types.LabelFilter and expects to receive a working squirrel.SelectBuilder
+func (s Store) SearchLabels(ctx context.Context, f types.LabelFilter) (types.LabelSet, types.LabelFilter, error) {
+	var (
+		err error
+		set []*types.Label
+		q   squirrel.SelectBuilder
+	)
+	q, err = s.convertLabelFilter(f)
+	if err != nil {
+		return nil, f, err
+	}
+
+	return set, f, s.config.ErrorHandler(func() error {
+		set, _, _, err = s.QueryLabels(ctx, q, nil)
+		return err
+
+	}())
+}
+
+// QueryLabels queries the database, converts and checks each row and
+// returns collected set
+//
+// Fn also returns total number of fetched items and last fetched item so that the caller can construct cursor
+// for next page of results
+func (s Store) QueryLabels(
+	ctx context.Context,
+	q squirrel.Sqlizer,
+	check func(*types.Label) (bool, error),
+) ([]*types.Label, uint, *types.Label, error) {
+	var (
+		set = make([]*types.Label, 0, DefaultSliceCapacity)
+		res *types.Label
+
+		// Query rows with
+		rows, err = s.Query(ctx, q)
+
+		fetched uint
+	)
+
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		fetched++
+		if err = rows.Err(); err == nil {
+			res, err = s.internalLabelRowScanner(rows)
+		}
+
+		if err != nil {
+			return nil, 0, nil, err
+		}
+
+		set = append(set, res)
+	}
+
+	return set, fetched, res, rows.Err()
+}
+
+// LookupLabelByKindResourceIDName Label lookup by kind, resource, name
+func (s Store) LookupLabelByKindResourceIDName(ctx context.Context, kind string, resource_id uint64, name string) (*types.Label, error) {
+	return s.execLookupLabel(ctx, squirrel.Eq{
+		s.preprocessColumn("lbl.kind", ""):         store.PreprocessValue(kind, ""),
+		s.preprocessColumn("lbl.rel_resource", ""): store.PreprocessValue(resource_id, ""),
+		s.preprocessColumn("lbl.name", "lower"):    store.PreprocessValue(name, "lower"),
+	})
+}
+
+// CreateLabel creates one or more rows in labels table
+func (s Store) CreateLabel(ctx context.Context, rr ...*types.Label) (err error) {
+	for _, res := range rr {
+		err = s.checkLabelConstraints(ctx, res)
+		if err != nil {
+			return err
+		}
+
+		err = s.execCreateLabels(ctx, s.internalLabelEncoder(res))
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+// UpdateLabel updates one or more existing rows in labels
+func (s Store) UpdateLabel(ctx context.Context, rr ...*types.Label) error {
+	return s.config.ErrorHandler(s.partialLabelUpdate(ctx, nil, rr...))
+}
+
+// partialLabelUpdate updates one or more existing rows in labels
+func (s Store) partialLabelUpdate(ctx context.Context, onlyColumns []string, rr ...*types.Label) (err error) {
+	for _, res := range rr {
+		err = s.checkLabelConstraints(ctx, res)
+		if err != nil {
+			return err
+		}
+
+		err = s.execUpdateLabels(
+			ctx,
+			squirrel.Eq{
+				s.preprocessColumn("lbl.kind", ""): store.PreprocessValue(res.Kind, ""), s.preprocessColumn("lbl.rel_resource", ""): store.PreprocessValue(res.ResourceID, ""), s.preprocessColumn("lbl.name", "lower"): store.PreprocessValue(res.Name, "lower"),
+			},
+			s.internalLabelEncoder(res).Skip("kind", "rel_resource", "name").Only(onlyColumns...))
+		if err != nil {
+			return s.config.ErrorHandler(err)
+		}
+	}
+
+	return
+}
+
+// UpsertLabel updates one or more existing rows in labels
+func (s Store) UpsertLabel(ctx context.Context, rr ...*types.Label) (err error) {
+	for _, res := range rr {
+		err = s.checkLabelConstraints(ctx, res)
+		if err != nil {
+			return err
+		}
+
+		err = s.config.ErrorHandler(s.execUpsertLabels(ctx, s.internalLabelEncoder(res)))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DeleteLabel Deletes one or more rows from labels table
+func (s Store) DeleteLabel(ctx context.Context, rr ...*types.Label) (err error) {
+	for _, res := range rr {
+
+		err = s.execDeleteLabels(ctx, squirrel.Eq{
+			s.preprocessColumn("lbl.kind", ""): store.PreprocessValue(res.Kind, ""), s.preprocessColumn("lbl.rel_resource", ""): store.PreprocessValue(res.ResourceID, ""), s.preprocessColumn("lbl.name", "lower"): store.PreprocessValue(res.Name, "lower"),
+		})
+		if err != nil {
+			return s.config.ErrorHandler(err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteLabelByKindResourceIDName Deletes row from the labels table
+func (s Store) DeleteLabelByKindResourceIDName(ctx context.Context, kind string, resourceID uint64, name string) error {
+	return s.execDeleteLabels(ctx, squirrel.Eq{
+		s.preprocessColumn("lbl.kind", ""):         store.PreprocessValue(kind, ""),
+		s.preprocessColumn("lbl.rel_resource", ""): store.PreprocessValue(resourceID, ""),
+		s.preprocessColumn("lbl.name", "lower"):    store.PreprocessValue(name, "lower"),
+	})
+}
+
+// TruncateLabels Deletes all rows from the labels table
+func (s Store) TruncateLabels(ctx context.Context) error {
+	return s.config.ErrorHandler(s.Truncate(ctx, s.labelTable()))
+}
+
+// execLookupLabel prepares Label query and executes it,
+// returning types.Label (or error)
+func (s Store) execLookupLabel(ctx context.Context, cnd squirrel.Sqlizer) (res *types.Label, err error) {
+	var (
+		row rowScanner
+	)
+
+	row, err = s.QueryRow(ctx, s.labelsSelectBuilder().Where(cnd))
+	if err != nil {
+		return
+	}
+
+	res, err = s.internalLabelRowScanner(row)
+	if err != nil {
+		return
+	}
+
+	return res, nil
+}
+
+// execCreateLabels updates all matched (by cnd) rows in labels with given data
+func (s Store) execCreateLabels(ctx context.Context, payload store.Payload) error {
+	return s.config.ErrorHandler(s.Exec(ctx, s.InsertBuilder(s.labelTable()).SetMap(payload)))
+}
+
+// execUpdateLabels updates all matched (by cnd) rows in labels with given data
+func (s Store) execUpdateLabels(ctx context.Context, cnd squirrel.Sqlizer, set store.Payload) error {
+	return s.config.ErrorHandler(s.Exec(ctx, s.UpdateBuilder(s.labelTable("lbl")).Where(cnd).SetMap(set)))
+}
+
+// execUpsertLabels inserts new or updates matching (by-primary-key) rows in labels with given data
+func (s Store) execUpsertLabels(ctx context.Context, set store.Payload) error {
+	upsert, err := s.config.UpsertBuilder(
+		s.config,
+		s.labelTable(),
+		set,
+		"kind",
+		"rel_resource",
+		"name",
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return s.config.ErrorHandler(s.Exec(ctx, upsert))
+}
+
+// execDeleteLabels Deletes all matched (by cnd) rows in labels with given data
+func (s Store) execDeleteLabels(ctx context.Context, cnd squirrel.Sqlizer) error {
+	return s.config.ErrorHandler(s.Exec(ctx, s.DeleteBuilder(s.labelTable("lbl")).Where(cnd)))
+}
+
+func (s Store) internalLabelRowScanner(row rowScanner) (res *types.Label, err error) {
+	res = &types.Label{}
+
+	if _, has := s.config.RowScanners["label"]; has {
+		scanner := s.config.RowScanners["label"].(func(_ rowScanner, _ *types.Label) error)
+		err = scanner(row, res)
+	} else {
+		err = row.Scan(
+			&res.Kind,
+			&res.ResourceID,
+			&res.Name,
+			&res.Value,
+		)
+	}
+
+	if err == sql.ErrNoRows {
+		return nil, store.ErrNotFound
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("could not scan db row for Label: %w", err)
+	} else {
+		return res, nil
+	}
+}
+
+// QueryLabels returns squirrel.SelectBuilder with set table and all columns
+func (s Store) labelsSelectBuilder() squirrel.SelectBuilder {
+	return s.SelectBuilder(s.labelTable("lbl"), s.labelColumns("lbl")...)
+}
+
+// labelTable name of the db table
+func (Store) labelTable(aa ...string) string {
+	var alias string
+	if len(aa) > 0 {
+		alias = " AS " + aa[0]
+	}
+
+	return "labels" + alias
+}
+
+// LabelColumns returns all defined table columns
+//
+// With optional string arg, all columns are returned aliased
+func (Store) labelColumns(aa ...string) []string {
+	var alias string
+	if len(aa) > 0 {
+		alias = aa[0] + "."
+	}
+
+	return []string{
+		alias + "kind",
+		alias + "rel_resource",
+		alias + "name",
+		alias + "value",
+	}
+}
+
+// {true true false false false}
+
+// internalLabelEncoder encodes fields from types.Label to store.Payload (map)
+//
+// Encoding is done by using generic approach or by calling encodeLabel
+// func when rdbms.customEncoder=true
+func (s Store) internalLabelEncoder(res *types.Label) store.Payload {
+	return store.Payload{
+		"kind":         res.Kind,
+		"rel_resource": res.ResourceID,
+		"name":         res.Name,
+		"value":        res.Value,
+	}
+}
+
+// checkLabelConstraints performs lookups (on valid) resource to check if any of the values on unique fields
+// already exists in the store
+//
+// Using built-in constraint checking would be more performant but unfortunately we can not rely
+// on the full support (MySQL does not support conditional indexes)
+func (s *Store) checkLabelConstraints(ctx context.Context, res *types.Label) error {
+	// Consider resource valid when all fields in unique constraint check lookups
+	// have valid (non-empty) value
+	//
+	// Only string and uint64 are supported for now
+	// feel free to add additional types if needed
+	var valid = true
+
+	valid = valid && len(res.Kind) > 0
+
+	valid = valid && res.ResourceID > 0
+
+	valid = valid && len(res.Name) > 0
+
+	if !valid {
+		return nil
+	}
+
+	{
+		ex, err := s.LookupLabelByKindResourceIDName(ctx, res.Kind, res.ResourceID, res.Name)
+		if err == nil && ex != nil && ex.Kind != res.Kind && ex.ResourceID != res.ResourceID && ex.Name != res.Name {
+			return store.ErrNotUnique
+		} else if !errors.Is(err, store.ErrNotFound) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/store/rdbms/labels.go
+++ b/store/rdbms/labels.go
@@ -1,0 +1,41 @@
+package rdbms
+
+import (
+	"context"
+	"github.com/Masterminds/squirrel"
+	"github.com/cortezaproject/corteza-server/pkg/label/types"
+)
+
+func (s Store) convertLabelFilter(f types.LabelFilter) (query squirrel.SelectBuilder, err error) {
+	query = s.labelsSelectBuilder()
+
+	query = query.Where(squirrel.Eq{"lbl.kind": f.Kind})
+
+	if len(f.ResourceID) > 0 {
+		query = query.Where(squirrel.Eq{"lbl.rel_resource": f.ResourceID})
+	}
+
+	if len(f.Filter) > 0 {
+		kvOr := squirrel.Or{}
+		for k, v := range f.Filter {
+			kvOr = append(kvOr, squirrel.Eq{"name": k, "value": v})
+		}
+		query = query.Where(kvOr)
+
+	}
+
+	return
+}
+
+// DeleteExtraLabels removes all unlisted labels
+func (s Store) DeleteExtraLabels(ctx context.Context, kind string, resourceID uint64, names ...string) (err error) {
+	return s.execDeleteLabels(ctx, squirrel.And{
+		squirrel.Eq{
+			"kind":         kind,
+			"rel_resource": resourceID,
+		},
+		squirrel.NotEq{
+			"name": names,
+		},
+	})
+}

--- a/store/rdbms/rdbms_schema.go
+++ b/store/rdbms/rdbms_schema.go
@@ -56,6 +56,7 @@ func (s Schema) Tables() []*Table {
 		s.ActionLog(),
 		s.RbacRules(),
 		s.Settings(),
+		s.Labels(),
 		s.ComposeAttachment(),
 		s.ComposeChart(),
 		s.ComposeModule(),
@@ -217,6 +218,17 @@ func (Schema) Settings() *Table {
 		ColumnDef("updated_at", ColumnTypeTimestamp),
 
 		AddIndex("unique_name", IExpr("LOWER(name)"), IColumn("rel_owner")),
+	)
+}
+
+func (Schema) Labels() *Table {
+	return TableDef("labels",
+		ColumnDef("kind", ColumnTypeVarchar, ColumnTypeLength(handleLength)),
+		ColumnDef("rel_resource", ColumnTypeIdentifier),
+		ColumnDef("name", ColumnTypeVarchar, ColumnTypeLength(resourceLength)),
+		ColumnDef("value", ColumnTypeText),
+
+		PrimaryKey(IColumn("kind", "rel_resource", "name")),
 	)
 }
 

--- a/store/rdbms/roles.go
+++ b/store/rdbms/roles.go
@@ -17,6 +17,10 @@ func (s Store) convertRoleFilter(f types.RoleFilter) (query squirrel.SelectBuild
 		query = query.Where(squirrel.Eq{"rl.ID": f.RoleID})
 	}
 
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"rl.id": f.LabeledIDs})
+	}
+
 	if f.MemberID > 0 {
 		query = query.Where(squirrel.Expr("rl.ID IN (SELECT rel_role FROM role_members AS m WHERE m.rel_user = ?)", f.MemberID))
 	}

--- a/store/rdbms/users.go
+++ b/store/rdbms/users.go
@@ -18,6 +18,10 @@ func (s Store) convertUserFilter(f types.UserFilter) (query squirrel.SelectBuild
 		query = query.Where(squirrel.Eq{"usr.ID": f.UserID})
 	}
 
+	if len(f.LabeledIDs) > 0 {
+		query = query.Where(squirrel.Eq{"usr.id": f.LabeledIDs})
+	}
+
 	if len(f.RoleID) > 0 {
 		or := squirrel.Or{}
 		// Due to lack of support for more exotic expressions (slice of values inside subquery)

--- a/store/tests/gen_test.go
+++ b/store/tests/gen_test.go
@@ -14,6 +14,7 @@ package tests
 //  - store/compose_namespaces.yaml
 //  - store/compose_pages.yaml
 //  - store/credentials.yaml
+//  - store/labels.yaml
 //  - store/messaging_attachments.yaml
 //  - store/messaging_channel_members.yaml
 //  - store/messaging_channels.yaml
@@ -98,6 +99,11 @@ func testAllGenerated(t *testing.T, s store.Storer) {
 	// Run generated tests for Credentials
 	t.Run("Credentials", func(t *testing.T) {
 		testCredentials(t, s)
+	})
+
+	// Run generated tests for Labels
+	t.Run("Labels", func(t *testing.T) {
+		testLabels(t, s)
 	})
 
 	// Run generated tests for MessagingAttachments

--- a/store/tests/labels_test.go
+++ b/store/tests/labels_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/label/types"
+	"github.com/cortezaproject/corteza-server/store"
+	_ "github.com/joho/godotenv/autoload"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func testLabels(t *testing.T, s store.Labels) {
+	var (
+		ctx = context.Background()
+	)
+
+	t.Run("create", func(t *testing.T) {
+		req := require.New(t)
+		req.NoError(s.TruncateLabels(ctx))
+		req.NoError(s.CreateLabel(ctx, &types.Label{
+			Kind:       "kind",
+			ResourceID: 1,
+			Name:       "lname",
+			Value:      "lvalue",
+		}))
+	})
+
+	t.Run("update", func(t *testing.T) {
+		req := require.New(t)
+		req.NoError(s.TruncateLabels(ctx))
+		req.NoError(s.UpdateLabel(ctx, &types.Label{
+			Kind:       "kind",
+			ResourceID: 1,
+			Name:       "lname",
+			Value:      "lvalue",
+		}))
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		req := require.New(t)
+		req.NoError(s.TruncateLabels(ctx))
+		req.NoError(s.UpsertLabel(ctx, &types.Label{
+			Kind:       "kind",
+			ResourceID: 1,
+			Name:       "lname",
+			Value:      "lvalue",
+		}))
+	})
+}

--- a/system/rest.yaml
+++ b/system/rest.yaml
@@ -233,6 +233,8 @@ endpoints:
   authentication:
   - Client ID
   - Session ID
+  imports:
+    - github.com/cortezaproject/corteza-server/pkg/label
   apis:
   - name: list
     method: GET
@@ -252,6 +254,10 @@ endpoints:
         required: false
         title: Exclude (0, default), include (1) or return only (2) achived roles
         type: uint
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: uint
         name: limit
         title: Limit
@@ -279,6 +285,10 @@ endpoints:
         name: members
         required: false
         title: Role member IDs
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: update
     method: PUT
     title: Update role details
@@ -302,6 +312,10 @@ endpoints:
         name: members
         required: false
         title: Role member IDs
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: read
     method: GET
     title: Read role details and memberships
@@ -442,6 +456,7 @@ endpoints:
   - Client ID
   - Session ID
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/label
     - github.com/cortezaproject/corteza-server/system/types
   apis:
   - name: list
@@ -494,6 +509,10 @@ endpoints:
         required: false
         title: Exclude (0, default), include (1) or return only (2) suspended users
         type: uint
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: uint
         name: limit
         title: Limit
@@ -525,6 +544,10 @@ endpoints:
         type: types.UserKind
         required: false
         title: Kind (normal, bot)
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: update
     method: PUT
     title: Update user details
@@ -552,6 +575,10 @@ endpoints:
         type: types.UserKind
         required: false
         title: Kind (normal, bot)
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: read
     method: GET
     title: Read user details
@@ -676,6 +703,7 @@ endpoints:
   entrypoint: application
   authentication: []
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/label
     - sqlxTypes github.com/jmoiron/sqlx/types
   apis:
   - name: list
@@ -696,6 +724,10 @@ endpoints:
         required: false
         title: Exclude (0, default), include (1) or return only (2) deleted roles
         type: uint
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
       - type: uint
         name: limit
         title: Limit
@@ -727,6 +759,10 @@ endpoints:
         type: sqlxTypes.JSONText
         required: false
         title: Arbitrary JSON holding application configuration
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: update
     method: PUT
     title: Update user details
@@ -754,6 +790,10 @@ endpoints:
         type: sqlxTypes.JSONText
         required: false
         title: Arbitrary JSON holding application configuration
+      - type: map[string]string
+        name: labels
+        title: Labels
+        parser: label.ParseStrings
   - name: read
     method: GET
     title: Read application details

--- a/system/rest/application.go
+++ b/system/rest/application.go
@@ -63,8 +63,9 @@ func (ctrl *Application) List(ctx context.Context, r *request.ApplicationList) (
 	var (
 		err error
 		f   = types.ApplicationFilter{
-			Name:  r.Name,
-			Query: r.Query,
+			Name:   r.Name,
+			Query:  r.Query,
+			Labels: r.Labels,
 
 			Deleted: filter.State(r.Deleted),
 		}
@@ -88,6 +89,7 @@ func (ctrl *Application) Create(ctx context.Context, r *request.ApplicationCreat
 		app = &types.Application{
 			Name:    r.Name,
 			Enabled: r.Enabled,
+			Labels:  r.Labels,
 		}
 	)
 
@@ -109,6 +111,7 @@ func (ctrl *Application) Update(ctx context.Context, r *request.ApplicationUpdat
 			ID:      r.ApplicationID,
 			Name:    r.Name,
 			Enabled: r.Enabled,
+			Labels:  r.Labels,
 		}
 	)
 

--- a/system/rest/request/role.go
+++ b/system/rest/request/role.go
@@ -11,6 +11,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi"
 	"io"
@@ -45,6 +46,11 @@ type (
 		// Exclude (0, default), include (1) or return only (2) achived roles
 		Archived uint
 
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
+
 		// Limit GET parameter
 		//
 		// Limit
@@ -76,6 +82,11 @@ type (
 		//
 		// Role member IDs
 		Members []string
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	RoleUpdate struct {
@@ -98,6 +109,11 @@ type (
 		//
 		// Role member IDs
 		Members []string
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	RoleRead struct {
@@ -214,6 +230,7 @@ func (r RoleList) Auditable() map[string]interface{} {
 		"query":      r.Query,
 		"deleted":    r.Deleted,
 		"archived":   r.Archived,
+		"labels":     r.Labels,
 		"limit":      r.Limit,
 		"pageCursor": r.PageCursor,
 		"sort":       r.Sort,
@@ -233,6 +250,11 @@ func (r RoleList) GetDeleted() uint {
 // Auditable returns all auditable/loggable parameters
 func (r RoleList) GetArchived() uint {
 	return r.Archived
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RoleList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -285,6 +307,17 @@ func (r *RoleList) Fill(req *http.Request) (err error) {
 				return err
 			}
 		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 		if val, ok := tmp["limit"]; ok && len(val) > 0 {
 			r.Limit, err = payload.ParseUint(val[0]), nil
 			if err != nil {
@@ -319,6 +352,7 @@ func (r RoleCreate) Auditable() map[string]interface{} {
 		"name":    r.Name,
 		"handle":  r.Handle,
 		"members": r.Members,
+		"labels":  r.Labels,
 	}
 }
 
@@ -335,6 +369,11 @@ func (r RoleCreate) GetHandle() string {
 // Auditable returns all auditable/loggable parameters
 func (r RoleCreate) GetMembers() []string {
 	return r.Members
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RoleCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -377,6 +416,18 @@ func (r *RoleCreate) Fill(req *http.Request) (err error) {
 		//        return err
 		//    }
 		//}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return err
@@ -394,6 +445,7 @@ func (r RoleUpdate) Auditable() map[string]interface{} {
 		"name":    r.Name,
 		"handle":  r.Handle,
 		"members": r.Members,
+		"labels":  r.Labels,
 	}
 }
 
@@ -415,6 +467,11 @@ func (r RoleUpdate) GetHandle() string {
 // Auditable returns all auditable/loggable parameters
 func (r RoleUpdate) GetMembers() []string {
 	return r.Members
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RoleUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -457,6 +514,18 @@ func (r *RoleUpdate) Fill(req *http.Request) (err error) {
 		//        return err
 		//    }
 		//}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	{

--- a/system/rest/request/user.go
+++ b/system/rest/request/user.go
@@ -11,6 +11,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/cortezaproject/corteza-server/system/types"
 	"github.com/go-chi/chi"
@@ -86,6 +87,11 @@ type (
 		// Exclude (0, default), include (1) or return only (2) suspended users
 		Suspended uint
 
+		// Labels GET parameter
+		//
+		// Labels
+		Labels map[string]string
+
 		// Limit GET parameter
 		//
 		// Limit
@@ -122,6 +128,11 @@ type (
 		//
 		// Kind (normal, bot)
 		Kind types.UserKind
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	UserUpdate struct {
@@ -149,6 +160,11 @@ type (
 		//
 		// Kind (normal, bot)
 		Kind types.UserKind
+
+		// Labels POST parameter
+		//
+		// Labels
+		Labels map[string]string
 	}
 
 	UserRead struct {
@@ -261,6 +277,7 @@ func (r UserList) Auditable() map[string]interface{} {
 		"incSuspended": r.IncSuspended,
 		"deleted":      r.Deleted,
 		"suspended":    r.Suspended,
+		"labels":       r.Labels,
 		"limit":        r.Limit,
 		"pageCursor":   r.PageCursor,
 		"sort":         r.Sort,
@@ -320,6 +337,11 @@ func (r UserList) GetDeleted() uint {
 // Auditable returns all auditable/loggable parameters
 func (r UserList) GetSuspended() uint {
 	return r.Suspended
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r UserList) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -430,6 +452,17 @@ func (r *UserList) Fill(req *http.Request) (err error) {
 				return err
 			}
 		}
+		if val, ok := tmp["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 		if val, ok := tmp["limit"]; ok && len(val) > 0 {
 			r.Limit, err = payload.ParseUint(val[0]), nil
 			if err != nil {
@@ -465,6 +498,7 @@ func (r UserCreate) Auditable() map[string]interface{} {
 		"name":   r.Name,
 		"handle": r.Handle,
 		"kind":   r.Kind,
+		"labels": r.Labels,
 	}
 }
 
@@ -486,6 +520,11 @@ func (r UserCreate) GetHandle() string {
 // Auditable returns all auditable/loggable parameters
 func (r UserCreate) GetKind() types.UserKind {
 	return r.Kind
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r UserCreate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -535,6 +574,18 @@ func (r *UserCreate) Fill(req *http.Request) (err error) {
 				return err
 			}
 		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return err
@@ -553,6 +604,7 @@ func (r UserUpdate) Auditable() map[string]interface{} {
 		"name":   r.Name,
 		"handle": r.Handle,
 		"kind":   r.Kind,
+		"labels": r.Labels,
 	}
 }
 
@@ -579,6 +631,11 @@ func (r UserUpdate) GetHandle() string {
 // Auditable returns all auditable/loggable parameters
 func (r UserUpdate) GetKind() types.UserKind {
 	return r.Kind
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r UserUpdate) GetLabels() map[string]string {
+	return r.Labels
 }
 
 // Fill processes request and fills internal variables
@@ -624,6 +681,18 @@ func (r *UserUpdate) Fill(req *http.Request) (err error) {
 
 		if val, ok := req.Form["kind"]; ok && len(val) > 0 {
 			r.Kind, err = types.UserKind(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["labels[]"]; ok {
+			r.Labels, err = label.ParseStrings(val)
+			if err != nil {
+				return err
+			}
+		} else if val, ok := req.Form["labels"]; ok {
+			r.Labels, err = label.ParseStrings(val)
 			if err != nil {
 				return err
 			}

--- a/system/rest/role.go
+++ b/system/rest/role.go
@@ -59,7 +59,8 @@ func (ctrl Role) List(ctx context.Context, r *request.RoleList) (interface{}, er
 	var (
 		err error
 		f   = types.RoleFilter{
-			Query: r.Query,
+			Query:  r.Query,
+			Labels: r.Labels,
 
 			Archived: filter.State(r.Archived),
 			Deleted:  filter.State(r.Deleted),
@@ -84,6 +85,7 @@ func (ctrl Role) Create(ctx context.Context, r *request.RoleCreate) (interface{}
 		role = &types.Role{
 			Name:   r.Name,
 			Handle: r.Handle,
+			Labels: r.Labels,
 		}
 	)
 
@@ -108,6 +110,7 @@ func (ctrl Role) Update(ctx context.Context, r *request.RoleUpdate) (interface{}
 			ID:     r.RoleID,
 			Name:   r.Name,
 			Handle: r.Handle,
+			Labels: r.Labels,
 		}
 	)
 

--- a/system/rest/user.go
+++ b/system/rest/user.go
@@ -46,6 +46,7 @@ func (ctrl User) List(ctx context.Context, r *request.UserList) (interface{}, er
 			Username:  r.Username,
 			Handle:    r.Handle,
 			Kind:      r.Kind,
+			Labels:    r.Labels,
 			Suspended: filter.State(r.Suspended),
 			Deleted:   filter.State(r.Deleted),
 		}
@@ -77,6 +78,7 @@ func (ctrl User) Create(ctx context.Context, r *request.UserCreate) (interface{}
 		Name:   r.Name,
 		Handle: r.Handle,
 		Kind:   r.Kind,
+		Labels: r.Labels,
 	}
 
 	return ctrl.user.With(ctx).Create(user)
@@ -89,6 +91,7 @@ func (ctrl User) Update(ctx context.Context, r *request.UserUpdate) (interface{}
 		Name:   r.Name,
 		Handle: r.Handle,
 		Kind:   r.Kind,
+		Labels: r.Labels,
 	}
 
 	return ctrl.user.With(ctx).Update(user)

--- a/system/service/user.go
+++ b/system/service/user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cortezaproject/corteza-server/pkg/eventbus"
 	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/handle"
+	"github.com/cortezaproject/corteza-server/pkg/label"
 	"github.com/cortezaproject/corteza-server/store"
 	"github.com/cortezaproject/corteza-server/system/service/event"
 	"github.com/cortezaproject/corteza-server/system/types"
@@ -142,8 +143,17 @@ func (svc user) FindByID(userID uint64) (u *types.User, err error) {
 			return nil
 		}
 
-		u, err = svc.proc(store.LookupUserByID(svc.ctx, svc.store, userID))
-		return err
+		if u, err = svc.proc(store.LookupUserByID(svc.ctx, svc.store, userID)); err != nil {
+			return err
+		}
+
+		uaProps.setUser(u)
+
+		if err = label.Load(svc.ctx, svc.store, u); err != nil {
+			return err
+		}
+
+		return nil
 	}()
 
 	return u, svc.recordAction(svc.ctx, uaProps, UserActionLookup, err)
@@ -155,8 +165,17 @@ func (svc user) FindByEmail(email string) (u *types.User, err error) {
 	)
 
 	err = func() error {
-		u, err = svc.proc(store.LookupUserByEmail(svc.ctx, svc.store, email))
-		return err
+		if u, err = svc.proc(store.LookupUserByEmail(svc.ctx, svc.store, email)); err != nil {
+			return err
+		}
+
+		uaProps.setUser(u)
+
+		if err = label.Load(svc.ctx, svc.store, u); err != nil {
+			return err
+		}
+
+		return nil
 	}()
 
 	return u, svc.recordAction(svc.ctx, uaProps, UserActionLookup, err)
@@ -168,8 +187,17 @@ func (svc user) FindByUsername(username string) (u *types.User, err error) {
 	)
 
 	err = func() error {
-		u, err = svc.proc(store.LookupUserByUsername(svc.ctx, svc.store, username))
-		return err
+		if u, err = svc.proc(store.LookupUserByUsername(svc.ctx, svc.store, username)); err != nil {
+			return err
+		}
+
+		uaProps.setUser(u)
+
+		if err = label.Load(svc.ctx, svc.store, u); err != nil {
+			return err
+		}
+
+		return nil
 	}()
 
 	return u, svc.recordAction(svc.ctx, uaProps, UserActionLookup, err)
@@ -181,8 +209,17 @@ func (svc user) FindByHandle(handle string) (u *types.User, err error) {
 	)
 
 	err = func() error {
-		u, err = svc.proc(store.LookupUserByHandle(svc.ctx, svc.store, handle))
-		return err
+		if u, err = svc.proc(store.LookupUserByHandle(svc.ctx, svc.store, handle)); err != nil {
+			return err
+		}
+
+		uaProps.setUser(u)
+
+		if err = label.Load(svc.ctx, svc.store, u); err != nil {
+			return err
+		}
+
+		return nil
 	}()
 
 	return u, svc.recordAction(svc.ctx, uaProps, UserActionLookup, err)
@@ -273,8 +310,25 @@ func (svc user) Find(filter types.UserFilter) (uu types.UserSet, f types.UserFil
 			}
 		}
 
+		if len(filter.Labels) > 0 {
+			filter.LabeledIDs, err = label.Search(
+				svc.ctx,
+				svc.store,
+				types.User{}.LabelResourceKind(),
+				filter.Labels,
+			)
+
+			if err != nil {
+				return err
+			}
+		}
+
 		uu, f, err = store.SearchUsers(svc.ctx, svc.store, filter)
 		if err != nil {
+			return err
+		}
+
+		if err = label.Load(svc.ctx, svc.store, toLabeledUsers(uu)...); err != nil {
 			return err
 		}
 
@@ -343,6 +397,10 @@ func (svc user) Create(new *types.User) (u *types.User, err error) {
 			return
 		}
 
+		if err = label.Create(svc.ctx, svc.store, new); err != nil {
+			return
+		}
+
 		_ = svc.eventbus.WaitFor(svc.ctx, event.UserAfterCreate(new, u))
 		return
 	}()
@@ -403,6 +461,14 @@ func (svc user) Update(upd *types.User) (u *types.User, err error) {
 
 		if err = store.UpdateUser(svc.ctx, svc.store, u); err != nil {
 			return
+		}
+
+		if label.Changed(u.Labels, upd.Labels) {
+			if err = label.Update(svc.ctx, svc.store, upd); err != nil {
+				return
+			}
+
+			u.Labels = upd.Labels
 		}
 
 		_ = svc.eventbus.WaitFor(svc.ctx, event.UserAfterUpdate(upd, u))
@@ -725,4 +791,20 @@ func createHandle(ctx context.Context, s store.Users, u *types.User) {
 			//
 		)
 	}
+}
+
+// toLabeledUsers converts to []label.LabeledResource
+//
+// This function is auto-generated.
+func toLabeledUsers(set []*types.User) []label.LabeledResource {
+	if len(set) == 0 {
+		return nil
+	}
+
+	ll := make([]label.LabeledResource, len(set))
+	for i := range set {
+		ll[i] = set[i]
+	}
+
+	return ll
 }

--- a/system/types/applications.go
+++ b/system/types/applications.go
@@ -20,6 +20,8 @@ type (
 
 		Unify *ApplicationUnify `json:"unify,omitempty"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		CreatedAt time.Time  `json:"createdAt,omitempty"`
 		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 		DeletedAt *time.Time `json:"deletedAt,omitempty"`
@@ -38,6 +40,9 @@ type (
 	ApplicationFilter struct {
 		Name  string `json:"name"`
 		Query string `json:"query"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted filter.State `json:"deleted"`
 

--- a/system/types/role.go
+++ b/system/types/role.go
@@ -10,9 +10,12 @@ import (
 type (
 	// Role - An organisation may have many roles. Roles may have many channels available. Access to channels may be shared between roles.
 	Role struct {
-		ID         uint64     `json:"roleID,string"`
-		Name       string     `json:"name"`
-		Handle     string     `json:"handle"`
+		ID     uint64 `json:"roleID,string"`
+		Name   string `json:"name"`
+		Handle string `json:"handle"`
+
+		Labels map[string]string `json:"labels,omitempty"`
+
 		CreatedAt  time.Time  `json:"createdAt,omitempty"`
 		UpdatedAt  *time.Time `json:"updatedAt,omitempty"`
 		ArchivedAt *time.Time `json:"archivedAt,omitempty"`
@@ -30,6 +33,9 @@ type (
 
 		Deleted  filter.State `json:"deleted"`
 		Archived filter.State `json:"archived"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		// Check fn is called by store backend for each resource found function can
 		// modify the resource and return false if store should not return it

--- a/system/types/type_labels.gen.go
+++ b/system/types/type_labels.gen.go
@@ -1,0 +1,81 @@
+package types
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+// system/types/types.yaml
+
+// SetLabel adds new label to label map
+func (m *Application) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Application) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Application) LabelResourceKind() string {
+	return "application"
+}
+
+// GetLabels adds new label to label map
+func (m Application) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *Role) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m Role) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (Role) LabelResourceKind() string {
+	return "role"
+}
+
+// GetLabels adds new label to label map
+func (m Role) LabelResourceID() uint64 {
+	return m.ID
+}
+
+// SetLabel adds new label to label map
+func (m *User) SetLabel(key string, value string) {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+
+	m.Labels[key] = value
+}
+
+// GetLabels adds new label to label map
+func (m User) GetLabels() map[string]string {
+	return m.Labels
+}
+
+// GetLabels adds new label to label map
+func (User) LabelResourceKind() string {
+	return "user"
+}
+
+// GetLabels adds new label to label map
+func (m User) LabelResourceID() uint64 {
+	return m.ID
+}

--- a/system/types/types.yaml
+++ b/system/types/types.yaml
@@ -1,7 +1,10 @@
 types:
   User:
+    labelResourceType: user
   Application:
+    labelResourceType: application
   Role:
+    labelResourceType: role
   RoleMember:
     noIdField: true
   Credentials:

--- a/system/types/user.go
+++ b/system/types/user.go
@@ -25,6 +25,8 @@ type (
 
 		EmailConfirmed bool `json:"-"`
 
+		Labels map[string]string `json:"labels,omitempty"`
+
 		CreatedAt   time.Time  `json:"createdAt,omitempty"`
 		UpdatedAt   *time.Time `json:"updatedAt,omitempty"`
 		SuspendedAt *time.Time `json:"suspendedAt,omitempty"`
@@ -48,6 +50,9 @@ type (
 		Username string   `json:"username"`
 		Handle   string   `json:"handle"`
 		Kind     UserKind `json:"kind"`
+
+		LabeledIDs []uint64          `json:"-"`
+		Labels     map[string]string `json:"labels,omitempty"`
 
 		Deleted   filter.State `json:"deleted"`
 		Suspended filter.State `json:"suspended"`

--- a/tests/compose/chart_test.go
+++ b/tests/compose/chart_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cortezaproject/corteza-server/store"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	jsonpath "github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -222,4 +224,90 @@ func TestChartDelete(t *testing.T) {
 
 	res = h.lookupChartByID(res.ID)
 	h.a.NotNil(res.DeletedAt)
+}
+
+func TestChartLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearCharts()
+
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "read")
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "chart.create")
+	h.allow(types.ChartRBACResource.AppendWildcard(), "read")
+	h.allow(types.ChartRBACResource.AppendWildcard(), "update")
+	h.allow(types.ChartRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ns = h.makeNamespace("some-namespace")
+		ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.Chart{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/chart/", ns.ID),
+			types.Chart{Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.Chart{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/chart/%d", ns.ID, ID),
+			types.Chart{Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.ChartSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/chart/", ns.ID),
+			&set, url.Values{"labels": []string{"baz=123"}},
+		)
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }

--- a/tests/compose/main_test.go
+++ b/tests/compose/main_test.go
@@ -50,7 +50,7 @@ func init() {
 
 func InitTestApp() {
 	if testApp == nil {
-		ctx := cli.Context()
+		ctx := logger.ContextWithValue(cli.Context(), logger.MakeDebugLogger())
 
 		testApp = helpers.NewIntegrationTestApp(ctx, func(app *app.CortezaApp) (err error) {
 			service.DefaultStore = app.Store

--- a/tests/compose/module_test.go
+++ b/tests/compose/module_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cortezaproject/corteza-server/store"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	"github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -133,7 +135,7 @@ func TestModuleListQuery(t *testing.T) {
 		End()
 }
 
-func TestModuleList_filterForbiden(t *testing.T) {
+func TestModuleList_filterForbidden(t *testing.T) {
 	h := newHelper(t)
 	h.clearModules()
 
@@ -330,4 +332,157 @@ func TestModuleDelete(t *testing.T) {
 
 	res = h.lookupModuleByID(res.ID)
 	h.a.NotNil(res.DeletedAt)
+}
+
+func TestModuleLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearModules()
+
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "read")
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "module.create")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "read")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "update")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ns          = h.makeNamespace("some-namespace")
+		fieldID, ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.Module{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/module/", ns.ID),
+			types.Module{Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.Module{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/module/%d", ns.ID, ID),
+			types.Module{Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.ModuleSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/module/", ns.ID),
+			&set,
+			url.Values{"labels": []string{"baz=123"}},
+		)
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID).Labels)
+	})
+
+	t.Run("field create", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			ctx      = context.Background()
+			req      = require.New(t)
+			mod, err = store.LookupComposeModuleByID(ctx, service.DefaultStore, ID)
+
+			payload = struct{ Response *types.Module }{}
+		)
+
+		req.NoError(err)
+		req.NotNil(mod)
+		mod.Fields = append(mod.Fields, &types.ModuleField{
+			Kind:   "String",
+			Name:   "labeled",
+			Label:  "",
+			Labels: map[string]string{"fldfoo": "fldbar"},
+		})
+
+		h.apiInit().
+			Post(fmt.Sprintf("/namespace/%d/module/%d", ns.ID, ID)).
+			JSON(helpers.JSON(mod)).
+			Expect(t).
+			Status(http.StatusOK).
+			Assert(helpers.AssertNoErrors).
+			Assert(jsonpath.Equal(`$.response.fields[0].labels.fldfoo`, "fldbar")).
+			End().
+			JSON(&payload)
+
+		fieldID = payload.Response.Fields[0].ID
+
+	})
+
+	t.Run("field update", func(t *testing.T) {
+		if fieldID == 0 {
+			t.Skip("label/field create test not ran")
+		}
+
+		var (
+			ctx      = context.Background()
+			req      = require.New(t)
+			mod, err = store.LookupComposeModuleByID(ctx, service.DefaultStore, ID)
+		)
+
+		req.NoError(err)
+		req.NotNil(mod)
+		mod.Fields = append(mod.Fields, &types.ModuleField{
+			ID:     fieldID,
+			Kind:   "String",
+			Name:   "labeled",
+			Label:  "",
+			Labels: map[string]string{"fldfoo": "fldbaz"},
+		})
+
+		h.apiInit().
+			Post(fmt.Sprintf("/namespace/%d/module/%d", ns.ID, ID)).
+			JSON(helpers.JSON(mod)).
+			Expect(t).
+			Status(http.StatusOK).
+			Assert(helpers.AssertNoErrors).
+			Assert(jsonpath.Equal(`$.response.fields[0].labels.fldfoo`, "fldbaz")).
+			End()
+	})
 }

--- a/tests/compose/namespace_test.go
+++ b/tests/compose/namespace_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/cortezaproject/corteza-server/store"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	jsonpath "github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -192,4 +194,85 @@ func TestNamespaceDelete(t *testing.T) {
 
 	ns = h.lookupNamespaceByID(ns.ID)
 	h.a.NotNil(ns.DeletedAt)
+}
+
+func TestNamespaceLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearNamespaces()
+
+	h.allow(types.ComposeRBACResource, "namespace.create")
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "read")
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "update")
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.Namespace{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			"/namespace/",
+			types.Namespace{Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.Namespace{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d", ID),
+			&types.Namespace{Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.NamespaceSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t, "/namespace/", &set, url.Values{"labels": []string{"baz=123"}})
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }

--- a/tests/compose/page_test.go
+++ b/tests/compose/page_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cortezaproject/corteza-server/store"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	"github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -258,4 +260,92 @@ func TestPageTreeRead(t *testing.T) {
 		Assert(jsonpath.Equal(`$.response[2].title`, "p3")).
 		Assert(jsonpath.Equal(`$.response[3].title`, "p4")).
 		End()
+}
+
+func TestPageLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearPages()
+
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "read")
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "page.create")
+	h.allow(types.PageRBACResource.AppendWildcard(), "read")
+	h.allow(types.PageRBACResource.AppendWildcard(), "update")
+	h.allow(types.PageRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ns = h.makeNamespace("some-namespace")
+		ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.Page{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/page/", ns.ID),
+			types.Page{Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.Page{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(),
+			t,
+			fmt.Sprintf("/namespace/%d/page/%d", ns.ID, ID),
+			types.Page{Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.PageSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/page/", ns.ID),
+			&set,
+			url.Values{"labels": []string{"baz=123"}},
+		)
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }

--- a/tests/compose/record_test.go
+++ b/tests/compose/record_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	"github.com/steinfletcher/apitest"
 	"github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -551,5 +553,124 @@ func TestRecordFieldModulePermissionCheck(t *testing.T) {
 			})
 		})
 	}
+}
 
+func TestRecordLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearRecords()
+
+	h.allow(types.NamespaceRBACResource.AppendWildcard(), "read")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "read")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "record.create")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "record.update")
+	h.allow(types.ModuleRBACResource.AppendWildcard(), "record.read")
+
+	var (
+		ns  = h.makeNamespace("some-namespace")
+		mod = h.makeModule(ns, "some-module", &types.ModuleField{Kind: "String", Name: "dummy"})
+		ID  uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req = require.New(t)
+
+			payload = struct {
+				Response *types.Record
+			}{}
+
+			rec = &types.Record{
+				Values: types.RecordValueSet{&types.RecordValue{Name: "dummy", Value: "dummy"}},
+				Labels: map[string]string{
+					"foo": "bar",
+					"bar": "42",
+				},
+			}
+		)
+
+		h.apiInit().
+			Post(fmt.Sprintf("/namespace/%d/module/%d/record/", ns.ID, mod.ID)).
+			JSON(helpers.JSON(rec)).
+			Expect(t).
+			Status(http.StatusOK).
+			Assert(helpers.AssertNoErrors).
+			End().
+			JSON(&payload)
+
+		req.NotNil(payload.Response)
+		req.NotZero(payload.Response.ID)
+
+		h.a.Equal(payload.Response.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Response.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Response.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.Response.LabelResourceKind(), payload.Response.ID),
+			"response must match stored labels")
+
+		ID = payload.Response.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+
+			payload = struct {
+				Response *types.Record
+			}{}
+
+			rec = &types.Record{
+				ID:     ID,
+				Values: types.RecordValueSet{&types.RecordValue{Name: "dummy", Value: "dummy"}},
+				Labels: map[string]string{
+					"foo": "baz",
+					"baz": "123",
+				},
+			}
+		)
+
+		h.apiInit().
+			Post(fmt.Sprintf("/namespace/%d/module/%d/record/%d", ns.ID, mod.ID, ID)).
+			JSON(helpers.JSON(rec)).
+			Expect(t).
+			Status(http.StatusOK).
+			Assert(helpers.AssertNoErrors).
+			End().
+			JSON(&payload)
+		req.NotZero(payload.Response.ID)
+
+		// disabled for now
+		//req.Nil(payload.Response.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Response.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Response.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Response.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Response.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.Response.LabelResourceKind(), payload.Response.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.RecordSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("/namespace/%d/module/%d/record/", ns.ID, mod.ID),
+			&set, url.Values{"labels": []string{"baz=123"}},
+		)
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }

--- a/tests/helpers/app.go
+++ b/tests/helpers/app.go
@@ -13,6 +13,8 @@ import (
 )
 
 func NewIntegrationTestApp(ctx context.Context, initTestServices func(*app.CortezaApp) error) *app.CortezaApp {
+	logger.Init()
+
 	var (
 		a = app.New()
 	)
@@ -24,7 +26,7 @@ func NewIntegrationTestApp(ctx context.Context, initTestServices func(*app.Corte
 	a.Opt.Auth.Secret = string(rand.Bytes(32))
 	a.Opt.Auth.Expiry = time.Minute
 
-	a.Log = logger.MakeDebugLogger()
+	a.Log = logger.Default()
 
 	cli.HandleError(a.InitStore(ctx))
 	cli.HandleError(initTestServices(a))

--- a/tests/helpers/json.go
+++ b/tests/helpers/json.go
@@ -1,0 +1,11 @@
+package helpers
+
+import "encoding/json"
+
+func JSON(i interface{}) string {
+	if b, err := json.Marshal(i); err != nil {
+		panic(err)
+	} else {
+		return string(b)
+	}
+}

--- a/tests/helpers/labels.go
+++ b/tests/helpers/labels.go
@@ -1,0 +1,63 @@
+package helpers
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/label/types"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/steinfletcher/apitest"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func SetLabelsViaAPI(api *apitest.APITest, t *testing.T, endpoint string, in, out interface{}) {
+	var (
+		payload = struct {
+			Response interface{}
+		}{}
+		req *apitest.Request
+	)
+
+	payload.Response = out
+
+	if strings.HasPrefix(endpoint, "PUT ") {
+		// a little workaround for our inconsistencies...
+		req = api.Put(endpoint[4:])
+	} else {
+		req = api.Post(endpoint)
+	}
+
+	req.JSON(JSON(in)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(AssertNoErrors).
+		End().
+		JSON(&payload)
+}
+
+func SearchWithLabelsViaAPI(api *apitest.APITest, t *testing.T, endpoint string, res interface{}, labels url.Values) {
+	var payload = struct{ Response struct{ Set interface{} } }{}
+
+	payload.Response.Set = res
+
+	api.Get(endpoint).
+		QueryCollection(labels).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(AssertNoErrors).
+		End().
+		JSON(&payload)
+}
+
+func LoadLabelsFromStore(t *testing.T, s store.Storer, resKind string, id uint64) (sl map[string]string) {
+	ll, _, err := s.SearchLabels(context.Background(), types.LabelFilter{Kind: resKind})
+	require.NoError(t, err)
+	if len(ll) == 0 {
+		// small adjustment
+		return nil
+	}
+
+	return ll.FilterByResource(resKind, id)
+}

--- a/tests/system/application_test.go
+++ b/tests/system/application_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cortezaproject/corteza-server/system/types"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	"github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -182,4 +184,85 @@ func TestApplicationDelete(t *testing.T) {
 	res = h.lookupApplicationByID(res.ID)
 	h.a.NotNil(res)
 	h.a.NotNil(res.DeletedAt)
+}
+
+func TestApplicationLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearApplications()
+
+	h.allow(types.SystemRBACResource, "application.create")
+	h.allow(types.ApplicationRBACResource.AppendWildcard(), "read")
+	h.allow(types.ApplicationRBACResource.AppendWildcard(), "update")
+	h.allow(types.ApplicationRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.Application{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			"/application/",
+			types.Application{Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.Application{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("PUT /application/%d", ID),
+			&types.Application{Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		//req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.ApplicationSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t, "/application/", &set, url.Values{"labels": []string{"baz=123"}})
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }

--- a/tests/system/role_test.go
+++ b/tests/system/role_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cortezaproject/corteza-server/system/types"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	"github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -213,4 +215,85 @@ func TestRoleDelete(t *testing.T) {
 	res = h.lookupRoleByID(res.ID)
 	h.a.NotNil(res)
 	h.a.NotNil(res.DeletedAt)
+}
+
+func TestRoleLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearRoles()
+
+	h.allow(types.SystemRBACResource, "role.create")
+	h.allow(types.RoleRBACResource.AppendWildcard(), "read")
+	h.allow(types.RoleRBACResource.AppendWildcard(), "update")
+	h.allow(types.RoleRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.Role{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			"/roles/",
+			types.Role{Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.Role{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("PUT /roles/%d", ID),
+			&types.Role{Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		//req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.RoleSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t, "/roles/", &set, url.Values{"labels": []string{"baz=123"}})
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }

--- a/tests/system/user_test.go
+++ b/tests/system/user_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cortezaproject/corteza-server/system/types"
 	"github.com/cortezaproject/corteza-server/tests/helpers"
 	"github.com/steinfletcher/apitest-jsonpath"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -375,4 +377,85 @@ func TestUserDelete(t *testing.T) {
 		Status(http.StatusOK).
 		Assert(helpers.AssertNoErrors).
 		End()
+}
+
+func TestUserLabels(t *testing.T) {
+	h := newHelper(t)
+	h.clearUsers()
+
+	h.allow(types.SystemRBACResource, "user.create")
+	h.allow(types.UserRBACResource.AppendWildcard(), "read")
+	h.allow(types.UserRBACResource.AppendWildcard(), "update")
+	h.allow(types.UserRBACResource.AppendWildcard(), "delete")
+
+	var (
+		ID uint64
+	)
+
+	t.Run("create", func(t *testing.T) {
+		var (
+			req     = require.New(t)
+			payload = &types.User{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			"/users/",
+			types.User{Email: h.randEmail(), Labels: map[string]string{"foo": "bar", "bar": "42"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+
+		h.a.Equal(payload.Labels["foo"], "bar",
+			"labels must contain foo with value bar")
+		h.a.Equal(payload.Labels["bar"], "42",
+			"labels must contain bar with value 42")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+
+		ID = payload.ID
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req     = require.New(t)
+			payload = &types.User{}
+		)
+
+		helpers.SetLabelsViaAPI(h.apiInit(), t,
+			fmt.Sprintf("PUT /users/%d", ID),
+			&types.User{ID: ID, Email: h.randEmail(), Labels: map[string]string{"foo": "baz", "baz": "123"}},
+			payload,
+		)
+		req.NotZero(payload.ID)
+		//req.Nil(payload.UpdatedAt, "updatedAt must not change after changing labels")
+
+		req.Equal(payload.Labels["foo"], "baz",
+			"labels must contain foo with value baz")
+		req.NotContains(payload.Labels, "bar",
+			"labels must not contain bar")
+		req.Equal(payload.Labels["baz"], "123",
+			"labels must contain baz with value 123")
+		req.Equal(payload.Labels, helpers.LoadLabelsFromStore(t, service.DefaultStore, payload.LabelResourceKind(), payload.ID),
+			"response must match stored labels")
+	})
+
+	t.Run("search", func(t *testing.T) {
+		if ID == 0 {
+			t.Skip("label/create test not ran")
+		}
+
+		var (
+			req = require.New(t)
+			set = types.UserSet{}
+		)
+
+		helpers.SearchWithLabelsViaAPI(h.apiInit(), t, "/users/", &set, url.Values{"labels": []string{"baz=123"}})
+		req.NotEmpty(set)
+		req.NotNil(set.FindByID(ID))
+		req.NotNil(set.FindByID(ID).Labels)
+	})
 }


### PR DESCRIPTION
This is POC and intended for brainstorming only

It introduces ability to add labels on resources and use labels as filters.
ATM it labels are only implemented on compose Modules, plan is to add it to almost every other resource (where reasonable)

Examples of possible usages:
 - group resources (so we do not have to reply on handle prefixes)
 - mark federated records
 - store import references (ext ID)
 - mark resources that could be preloaded in Corredor
 - marking dependencies by automation scripts, workflow
 - ....

I'm also experimenting with ModuleLabelResourceType format, not sure were it will land (this is a bigger problem that touches RBAC resources as well...) might just be that we'll end up (for now) with RBAC-like format for label resources.

