### PR TITLE
Molding (working, temp name) POC // corteza workflows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Masterminds/squirrel v1.1.1-0.20191017225151-12f2162c8d8d
-	github.com/PaesslerAG/gval v1.0.1 // indirect
+	github.com/PaesslerAG/gval v1.0.1
 	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/SentimensRG/ctx v0.0.0-20180729130232-0bfd988c655d
 	github.com/crusttech/go-oidc v0.0.0-20180918092017-982855dad3e1

--- a/molding/check.go
+++ b/molding/check.go
@@ -1,0 +1,69 @@
+package molding
+
+import "fmt"
+
+func CheckNodes(nn ...Node) error {
+	return checkNodes(Nodes{}, nn...)
+}
+
+func checkNodes(callstack Nodes, nn ...Node) error {
+	// indexing callstack
+	var (
+		revStack = map[Node]bool{}
+		csString = callstack.String()
+	)
+	for _, n := range callstack {
+		revStack[n] = true
+	}
+
+	for _, n := range nn {
+		if revStack[n] {
+			// checking (indexed) callstack
+			// to see if node is already checked
+			//
+			// this is needed to prevent inf-loop checks in case
+			// of cyclic graphs (loop scenario)
+			return nil
+		}
+
+		switch c := n.(type) {
+		case Joiner:
+			if len(c.Paths()) == 0 {
+				return fmt.Errorf("expecting at least one input path for join gateway (%s)", csString)
+			}
+
+			for _, p := range c.Paths() {
+				nxt, is := p.(Iterator)
+				if !is {
+					return fmt.Errorf("invalid parent node used, does not implement Next() (%s)", csString)
+				}
+
+				if nxt.Next() != n {
+					return fmt.Errorf("invalid parent node used should point back ti join gateway node (%s)", csString)
+				}
+			}
+
+		case Finalizer:
+			return nil
+
+		case Tester:
+			if len(c.Paths()) == 0 {
+				return fmt.Errorf("expecting at least one output path for gateway (%s)", csString)
+			}
+
+			return checkNodes(append(callstack, c), c.Paths()...)
+
+		case Executor:
+			if c.Next() == nil {
+				return fmt.Errorf("next node of executor node not set (%s)", csString)
+			}
+
+			return checkNodes(append(callstack, c), c.Next())
+
+		default:
+			return fmt.Errorf("unknown node (%s)", csString)
+		}
+	}
+
+	return nil
+}

--- a/molding/gateway.go
+++ b/molding/gateway.go
@@ -1,0 +1,194 @@
+package molding
+
+import (
+	"context"
+	"fmt"
+	"github.com/PaesslerAG/gval"
+	"sync"
+)
+
+type (
+	gatewayPath struct {
+		expr string
+		eval gval.Evaluable
+		to   Node
+	}
+
+	joinGateway struct {
+		nodeRef string
+
+		// all parent nodes we'll wait to be executed before going to next node
+		paths []Iterator
+		next  Node
+
+		l sync.Mutex
+
+		scope map[Node]Variables
+	}
+
+	forkGateway struct {
+		nodeRef string
+		paths   Nodes
+	}
+
+	inclGateway struct {
+		nodeRef string
+		paths   []*gatewayPath
+	}
+
+	exclGateway struct {
+		nodeRef string
+		paths   []*gatewayPath
+	}
+)
+
+var (
+	_ Joiner = &joinGateway{}
+	_ Tester = &forkGateway{}
+	_ Tester = &inclGateway{}
+	_ Tester = &exclGateway{}
+)
+
+func NewGatewayCondition(expr string, to Node) *gatewayPath {
+	return &gatewayPath{expr: expr, to: to}
+}
+
+func NewGatewayNoCondition(to Node) *gatewayPath {
+	return &gatewayPath{to: to}
+}
+
+func initGatewayPaths(paths ...*gatewayPath) ([]*gatewayPath, error) {
+	var (
+		err error
+	)
+
+	for _, p := range paths {
+		if p.expr == "" {
+			continue
+		}
+
+		if p.eval, err = gval.Full().NewEvaluable(p.expr); err != nil {
+			return nil, fmt.Errorf("can not parse %s: %w", p.expr, err)
+		}
+	}
+
+	return paths, err
+}
+
+func NewJoinGateway(paths ...Iterator) (*joinGateway, error) {
+	join := &joinGateway{
+		paths: paths,
+		scope: make(map[Node]Variables),
+	}
+	for _, p := range paths {
+		p.SetNext(join)
+	}
+	return join, nil
+}
+
+func (gw *joinGateway) NodeRef() string { return gw.nodeRef }
+func (gw *joinGateway) Next() Node      { return gw.next }
+func (gw *joinGateway) SetNext(n Node)  { gw.next = n }
+func (gw *joinGateway) Paths() Nodes {
+	var pp = make(Nodes, 0, len(gw.paths))
+	for _, p := range gw.paths {
+		pp = append(pp, p)
+	}
+
+	return pp
+}
+
+func (gw *joinGateway) Join(p Node, scope Variables) (Node, Variables, error) {
+	gw.l.Lock()
+	defer gw.l.Unlock()
+
+	// Allow scope overriding (in case when
+	// parent is executed again
+	//
+	// This covers scenario where we route workflow back to one
+	// of the nodes that is then joined
+	gw.scope[p] = scope
+
+	if len(gw.scope) < len(gw.paths) {
+		// Not all collected
+		return nil, nil, nil
+	}
+
+	// All collected, merge scope from all paths in the
+	// defined order
+	var out = Variables{}
+	for _, p := range gw.paths {
+		out = out.Merge(gw.scope[p])
+	}
+
+	return gw.next, out, nil
+}
+
+func NewForkGateway(paths ...Node) (*forkGateway, error) { return &forkGateway{paths: paths}, nil }
+
+func (gw forkGateway) NodeRef() string                                    { return gw.nodeRef }
+func (gw forkGateway) Paths() Nodes                                       { return gw.paths }
+func (gw forkGateway) Test(_ context.Context, _ Variables) (Nodes, error) { return gw.paths, nil }
+
+// multiple matches
+func NewInclGateway(paths ...*gatewayPath) (*inclGateway, error) {
+	var err error
+	paths, err = initGatewayPaths(paths...)
+	return &inclGateway{paths: paths}, err
+}
+
+func (gw inclGateway) NodeRef() string { return gw.nodeRef }
+func (gw inclGateway) Paths() Nodes {
+	var paths Nodes
+	for _, p := range gw.paths {
+		paths = append(paths, p.to)
+	}
+	return paths
+}
+
+// Test returns nodes from all paths that have a matching condition (or no condition at all)
+func (gw inclGateway) Test(ctx context.Context, scope Variables) (to Nodes, err error) {
+	for _, p := range gw.paths {
+		if result, err := p.eval.EvalBool(ctx, scope); err != nil {
+			return nil, err
+		} else if result {
+			to = append(to, p.to)
+		}
+	}
+
+	return
+}
+
+// single match
+func NewExclGateway(paths ...*gatewayPath) (*exclGateway, error) {
+	var err error
+	paths, err = initGatewayPaths(paths...)
+	return &exclGateway{paths: paths}, err
+}
+
+func (gw exclGateway) NodeRef() string { return gw.nodeRef }
+func (gw exclGateway) Paths() Nodes {
+	var paths Nodes
+	for _, p := range gw.paths {
+		paths = append(paths, p.to)
+	}
+	return paths
+}
+
+// Test returns first path with matching condition
+func (gw exclGateway) Test(ctx context.Context, scope Variables) (to Nodes, err error) {
+	for i, p := range gw.paths {
+		if len(p.expr) == 0 && i == len(gw.paths)-1 {
+			// empty & last; treat it as else
+			return Nodes{p.to}, nil
+		}
+
+		if result, err := p.eval.EvalBool(ctx, scope); err != nil {
+			return nil, err
+		} else if result {
+			return Nodes{p.to}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not match any of conditions")
+}

--- a/molding/graph.go
+++ b/molding/graph.go
@@ -1,0 +1,205 @@
+package molding
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type (
+	Nodes []Node
+
+	Node interface {
+		NodeRef() string
+	}
+
+	Iterator interface {
+		Node
+
+		// Returns next node
+		Next() Node
+
+		// Sets next node
+		//
+		// When configuring complex workflows with
+		// loops & join gateways we need explicitly
+		// add edges
+		SetNext(Node)
+	}
+
+	Joiner interface {
+		Iterator
+
+		// Consumes parent node and scope variables
+		//
+		// Returns non-nil when Join fn is called with all parents
+		Join(Node, Variables) (Node, Variables, error)
+
+		// Returns all possible input paths
+		// @todo think about naming here,
+		//       we have Next() that returns one node and Paths() that returns multiple
+		Paths() Nodes
+	}
+
+	Tester interface {
+		Node
+
+		// Returns one or more nodes that satisfy the configured conditions
+		//
+		// Always returns at least one node
+		Test(context.Context, Variables) (Nodes, error)
+
+		// Returns all possible output paths
+		// @todo think about naming here,
+		//       we have Next() that returns one node and Paths() that returns multiple
+		Paths() Nodes
+	}
+
+	Executor interface {
+		Iterator
+		Exec(context.Context, Variables) (Variables, error)
+	}
+
+	Finalizer interface {
+		Node
+		Finalize(context.Context, Variables) error
+	}
+
+	queue chan *payload
+
+	payload struct {
+		node  Node
+		prev  Node
+		scope Variables
+	}
+
+	workflow struct {
+		wg sync.WaitGroup
+		l  sync.Mutex
+
+		queue queue
+		err   chan error
+
+		counter map[Node]int
+	}
+)
+
+func (q queue) push(s Variables, p Node, nn ...Node) {
+	for _, n := range nn {
+		q <- &payload{scope: s, prev: p, node: n}
+	}
+}
+
+func Workflow(ctx context.Context, start Node, scope Variables) error {
+	if err := CheckNodes(start); err != nil {
+		return err
+	}
+
+	var (
+		e = &workflow{
+			queue:   make(queue, 512),
+			err:     make(chan error, 1),
+			counter: make(map[Node]int),
+		}
+	)
+
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		e.loop(ctx)
+	}()
+
+	e.queue.push(scope, nil, start)
+	e.wg.Wait()
+
+	select {
+	case err := <-e.err:
+		return err
+	default:
+		return nil
+	}
+}
+
+func (e *workflow) loop(ctx context.Context) {
+	for {
+		select {
+		case err := <-e.err:
+			e.err <- err
+			return
+
+		case p := <-e.queue:
+			if p == nil {
+				// processing queue closed
+				return
+			}
+
+			e.wg.Add(1)
+			func() {
+				defer e.wg.Done()
+				if err := e.proc(ctx, p.prev, p.node, p.scope); err != nil {
+					e.err <- err
+				}
+			}()
+
+		}
+	}
+}
+
+func (e *workflow) proc(ctx context.Context, p Node, n Node, scope Variables) error {
+	e.l.Lock()
+	defer e.l.Unlock()
+	e.counter[n]++
+
+	switch c := n.(type) {
+	case Joiner:
+		next, joinedScope, err := c.Join(p, scope)
+		if err != nil {
+			return err
+		}
+
+		if next == nil {
+			// no next node, waiting for all paths to execute
+			return nil
+		}
+
+		e.queue.push(joinedScope, c, c.Next())
+
+	case Finalizer:
+		if err := c.Finalize(ctx, scope); err != nil {
+			return err
+		}
+
+		close(e.queue)
+
+	case Tester:
+		paths, err := c.Test(ctx, scope)
+		if err != nil {
+			return err
+		}
+		e.queue.push(scope, c, paths...)
+
+	case Executor:
+		results, err := c.Exec(ctx, scope)
+		if err != nil {
+			return err
+		}
+		e.queue.push(scope.Merge(results), c, c.Next())
+
+	default:
+		return fmt.Errorf("useless node")
+	}
+
+	return nil
+}
+
+func (nn Nodes) String() string {
+	path := ""
+	for i := range nn {
+		if i > 0 {
+			path += "."
+		}
+		path += nn[i].NodeRef()
+	}
+
+	return path
+}

--- a/molding/graph_test.go
+++ b/molding/graph_test.go
@@ -1,0 +1,115 @@
+package molding
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type (
+	testEndEvent struct{ scope Variables }
+)
+
+var (
+	_ Finalizer = &testEndEvent{}
+)
+
+func NewTestEndEvent() *testEndEvent                                  { return &testEndEvent{} }
+func (t *testEndEvent) Finalize(_ context.Context, s Variables) error { t.scope = s; return nil }
+func (testEndEvent) NodeRef() string                                  { return "end-event" }
+
+func MustMakeNode(n Node, err error) Node {
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func TestRun_Set(t *testing.T) {
+	var (
+		req = require.New(t)
+		ctx = context.Background()
+		ee  = NewTestEndEvent()
+		sa  = MustMakeNode(NewSetActivity(ee, Expr("foo", `"bar"`)))
+	)
+
+	req.NoError(Workflow(ctx, sa, Variables{}))
+	req.Equal(ee.scope["foo"], "bar")
+}
+
+func TestRun_Condition(t *testing.T) {
+	var (
+		req = require.New(t)
+		ctx = context.Background()
+
+		ee  = NewTestEndEvent()
+		bar = MustMakeNode(NewSetActivity(ee, Expr("foo", `"bar"`)))
+		baz = MustMakeNode(NewSetActivity(ee, Expr("foo", `"baz"`)))
+
+		cnd = MustMakeNode(NewExclGateway(
+			NewGatewayCondition("setFooToBar", bar),
+			NewGatewayNoCondition(baz),
+		))
+	)
+
+	req.NoError(Workflow(ctx, cnd, Variables{"setFooToBar": true}))
+	req.Equal(ee.scope["foo"], "bar")
+	req.NoError(Workflow(ctx, cnd, Variables{"setFooToBar": false}))
+	req.Equal(ee.scope["foo"], "baz")
+}
+
+func TestRun_Loop(t *testing.T) {
+	var (
+		req = require.New(t)
+		ctx = context.Background()
+
+		ee  = NewTestEndEvent()
+		inc = MustMakeNode(NewSetActivity(nil, Expr("counter", `counter + 1`)))
+
+		cnd = MustMakeNode(NewExclGateway(
+			NewGatewayCondition("counter < 5", inc),
+			NewGatewayNoCondition(ee),
+		))
+	)
+
+	inc.(*setActivity).SetNext(cnd)
+
+	req.NoError(Workflow(ctx, cnd, Variables{"counter": 0}))
+	req.Equal(float64(5), ee.scope["counter"])
+}
+
+func TestRun_Join(t *testing.T) {
+	var (
+		req = require.New(t)
+		ctx = context.Background()
+
+		ee  = NewTestEndEvent()
+		foo = MustMakeNode(NewSetActivity(nil, Expr("foo", `"set"`), Expr("count", "count + 1"), Expr("order", "1")))
+		bar = MustMakeNode(NewSetActivity(nil, Expr("bar", `"set"`), Expr("count", "count + 1"), Expr("order", "2")))
+		baz = MustMakeNode(NewSetActivity(nil, Expr("baz", `"set"`), Expr("count", "count + 1"), Expr("order", "3")))
+
+		fork = MustMakeNode(NewForkGateway(foo, bar, baz))
+		join = MustMakeNode(NewJoinGateway(foo.(Iterator), bar.(Iterator), baz.(Iterator)))
+	)
+
+	join.(*joinGateway).SetNext(ee)
+
+	req.NoError(Workflow(ctx, fork, Variables{
+		"setFooToBar": true,
+		"count":       0,
+		"order":       0,
+	}))
+
+	// test if all paths are executed
+	// all there should be set
+	req.Equal(ee.scope["foo"], "set")
+	req.Equal(ee.scope["bar"], "set")
+	req.Equal(ee.scope["baz"], "set")
+
+	// tests if paths are isolated;
+	// expecting 1, all setters start with scope where count==0
+	req.Equal(ee.scope["count"], float64(1))
+	// tests if scope from paths merged in proper order
+	// expecting 3 - value from the node last added to the join
+	req.Equal(ee.scope["order"], float64(3))
+}

--- a/molding/setter.go
+++ b/molding/setter.go
@@ -1,0 +1,86 @@
+package molding
+
+import (
+	"context"
+	"fmt"
+	"github.com/PaesslerAG/gval"
+	"strings"
+)
+
+type (
+	expr struct {
+		// target for the result of the evaluated expression
+		target string
+
+		// expression
+		source string
+
+		// expression, ready to be executed
+		eval gval.Evaluable
+	}
+
+	setActivity struct {
+		next Node
+
+		// List of expressions that will be evaluated
+		// with given scope
+		expressions []*expr
+	}
+)
+
+var (
+	_ Executor = &setActivity{}
+)
+
+func Expr(dst, source string) *expr {
+	return &expr{target: dst, source: source}
+}
+
+func NewSetActivity(next Node, ee ...*expr) (*setActivity, error) {
+	var (
+		err error
+		set = &setActivity{
+			next:        next,
+			expressions: ee,
+		}
+
+		lang = gval.Full()
+	)
+
+	for _, e := range set.expressions {
+		if e.eval, err = lang.NewEvaluable(e.source); err != nil {
+			return nil, fmt.Errorf("can no parse %s for %s: %w", e.source, e.target, err)
+		}
+	}
+
+	return set, nil
+}
+
+func (s setActivity) NodeRef() string { return "setter" }
+func (s setActivity) Next() Node      { return s.next }
+func (s *setActivity) SetNext(n Node) { s.next = n }
+
+func (s setActivity) Exec(ctx context.Context, params Variables) (Variables, error) {
+	var (
+		err error
+
+		// Create scope from params
+		//
+		// We'll use it for evaluation of preconfigured expressions on the setter
+		// and as a container for each value that comes out of that evaluation
+		scope = params.Merge()
+	)
+
+	for _, e := range s.expressions {
+		if strings.Contains(e.target, ".") {
+			// handle property setting
+			return nil, fmt.Errorf("no support for prop setting ATM")
+		}
+
+		if scope[e.target], err = e.eval(ctx, scope); err != nil {
+			return nil, fmt.Errorf("could not evaluate %s for %s: %w", e.source, e.target, err)
+		}
+	}
+
+	return scope, nil
+}

--- a/molding/variables.go
+++ b/molding/variables.go
@@ -1,0 +1,75 @@
+package molding
+
+import "strconv"
+
+type (
+	//Type interface {
+	//	Kind() string
+	//}
+
+	Variables map[string]interface{}
+)
+
+// Assign takes base variables and assigns all new variables
+func (vv Variables) Merge(nn ...Variables) Variables {
+	var (
+		out = Variables{}
+	)
+
+	nn = append([]Variables{vv}, nn...)
+	for i := range nn {
+		for k, v := range nn[i] {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+func (vv Variables) Bool(key string, def bool) bool {
+	if v, has := vv[key]; has {
+		// @todo handle other types than string...
+		o, err := strconv.ParseBool(v.(string))
+		if err != nil {
+			return o
+		}
+	}
+
+	return def
+}
+
+func (vv Variables) Int64(key string, def int64) int64 {
+	if v, has := vv[key]; has {
+		// @todo handle other types than string...
+		o, err := strconv.ParseInt(v.(string), 10, 64)
+		if err != nil {
+			return o
+		}
+	}
+
+	return def
+}
+
+func (vv Variables) Uint64(key string, def uint64) uint64 {
+	if v, has := vv[key]; has {
+		// @todo handle other types than string...
+		o, err := strconv.ParseUint(v.(string), 10, 64)
+		if err != nil {
+			return o
+		}
+	}
+
+	return def
+}
+
+func (vv Variables) Float64(key string, def float64) float64 {
+	if v, has := vv[key]; has {
+		// @todo handle other types than string...
+		o, err := strconv.ParseFloat(v.(string), 64)
+		if err != nil {
+			return o
+		}
+	}
+
+	return def
+}

--- a/molding/variables_test.go
+++ b/molding/variables_test.go
@@ -1,0 +1,26 @@
+package molding
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVariablesCopy(t *testing.T) {
+	var (
+		req = require.New(t)
+		vv  Variables
+	)
+
+	req.Empty(vv)
+
+	vv = vv.Merge(Variables{"a": 1})
+	req.Contains(vv, "a")
+
+	vv = Variables{"a": 1}.Merge()
+	req.Contains(vv, "a")
+
+	vv = Variables{"a": 1}.Merge(Variables{"b": 2}, Variables{"c": 3})
+	req.Contains(vv, "a")
+	req.Contains(vv, "b")
+	req.Contains(vv, "b")
+}


### PR DESCRIPTION
It introduces a configurable way to handle automation in Corteza.
It can already handle simple workflows and tasks, using expressions etc. 

Notes:
 - code is not 100% working
 - yaml example might not make sense ;)
 - waiting for https://github.com/PaesslerAG/gval/issues/45 to see how we'll implement record value modifications

Goals:
 - should be configurable through human readable format (json, yaml)
 - should be storable (json)
 - should use terminology close to BPMN
 - core should handle gateways (decisions and loops) & activities (executables)
 - provide a rich UI that will allow designing complex workflows

Rough sketch of implementation:
 - workflow is defined as cyclic graph 
 - nodes have items that can join or split paths (gateway) or execute activity
 - execution holds variables ("scope") that can be accessed and/or modified by gateways and activities

Core stuff TODO
 - prevent infinite loops
 - executables should provide list of (required) arguments
 - executables should provide list of outputs
 - assign variables to executable arguments 
 - assign outputs to variables
 - init wf from configuration
 - ability to halt execution session, wait for (external) input, event, etc and resume from there

General TODO
 - implement various activities (record, module ... lookups, searches, sending emails fetching urls etc etc...)

