### PR TITLE
Fix support for min.io with Google Cloud Storage

### DIFF
--- a/compose/service/service.go
+++ b/compose/service/service.go
@@ -108,7 +108,7 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, c Config) 
 		if c.Storage.MinioEndpoint != "" {
 			var bucket = svcPath
 			if c.Storage.MinioBucket != "" {
-				bucket = c.Storage.MinioBucket + "/" + svcPath
+				bucket = c.Storage.MinioBucket + "-" + svcPath
 			}
 
 			DefaultObjectStore, err = minio.New(bucket, minio.Options{

--- a/compose/service/service.go
+++ b/compose/service/service.go
@@ -108,7 +108,7 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, c Config) 
 		if c.Storage.MinioEndpoint != "" {
 			var bucket = svcPath
 			if c.Storage.MinioBucket != "" {
-				bucket = c.Storage.MinioBucket + "-" + svcPath
+				bucket = c.Storage.MinioBucket + c.Storage.MinioBucketSep + svcPath
 			}
 
 			DefaultObjectStore, err = minio.New(bucket, minio.Options{

--- a/pkg/options/objectStore.gen.go
+++ b/pkg/options/objectStore.gen.go
@@ -26,7 +26,7 @@ type (
 func ObjectStore() (o *ObjectStoreOpt) {
 	o = &ObjectStoreOpt{
 		Path:           "var/store",
-		MinioBucketSep: "/"
+		MinioBucketSep: "/",
 		MinioSecure:    true,
 		MinioStrict:    false,
 	}

--- a/pkg/options/objectStore.gen.go
+++ b/pkg/options/objectStore.gen.go
@@ -17,6 +17,7 @@ type (
 		MinioSecretKey string `env:"MINIO_SECRET_KEY"`
 		MinioSSECKey   string `env:"MINIO_SSEC_KEY"`
 		MinioBucket    string `env:"MINIO_BUCKET"`
+		MinioBucketSep string `env:"MINIO_BUCKET_SEP"`
 		MinioStrict    bool   `env:"MINIO_STRICT"`
 	}
 )
@@ -24,9 +25,10 @@ type (
 // ObjectStore initializes and returns a ObjectStoreOpt with default values
 func ObjectStore() (o *ObjectStoreOpt) {
 	o = &ObjectStoreOpt{
-		Path:        "var/store",
-		MinioSecure: true,
-		MinioStrict: false,
+		Path:           "var/store",
+		MinioBucketSep: "/"
+		MinioSecure:    true,
+		MinioStrict:    false,
 	}
 
 	fill(o)

--- a/pkg/options/objectStore.yaml
+++ b/pkg/options/objectStore.yaml
@@ -30,6 +30,11 @@ props:
   - name: minioBucket
     env: MINIO_BUCKET
 
+  - name: minioBucket
+    env: MINIO_BUCKET_SEP
+    default: "/"
+    description: Used between MINIO_BUCKET and the service name (e.g system). Ignored if MINIO_BUCKET is not set. Required in latest versions of min.io since "/" is not accepted anymore in bucket names.
+
   - name: minioStrict
     type: bool
     env: MINIO_STRICT

--- a/pkg/options/objectStore.yaml
+++ b/pkg/options/objectStore.yaml
@@ -30,7 +30,7 @@ props:
   - name: minioBucket
     env: MINIO_BUCKET
 
-  - name: minioBucket
+  - name: minioBucketSep
     env: MINIO_BUCKET_SEP
     default: "/"
     description: Used between MINIO_BUCKET and the service name (e.g system). Ignored if MINIO_BUCKET is not set. Required in latest versions of min.io since "/" is not accepted anymore in bucket names.

--- a/system/service/service.go
+++ b/system/service/service.go
@@ -123,7 +123,7 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, c Config) 
 		if c.Storage.MinioEndpoint != "" {
 			var bucket = svcPath
 			if c.Storage.MinioBucket != "" {
-				bucket = c.Storage.MinioBucket + "/" + svcPath
+				bucket = c.Storage.MinioBucket + "-" + svcPath
 			}
 
 			DefaultObjectStore, err = minio.New(bucket, minio.Options{

--- a/system/service/service.go
+++ b/system/service/service.go
@@ -123,7 +123,7 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, c Config) 
 		if c.Storage.MinioEndpoint != "" {
 			var bucket = svcPath
 			if c.Storage.MinioBucket != "" {
-				bucket = c.Storage.MinioBucket + "-" + svcPath
+				bucket = c.Storage.MinioBucket + c.Storage.MinioBucketSep + svcPath
 			}
 
 			DefaultObjectStore, err = minio.New(bucket, minio.Options{


### PR DESCRIPTION
## The bug
Defining `MINIO_BUCKET` breaks `corteza-server`.

Seems like `/` is not a valid character to be used in a bucket name, according to the errors thrown by Min.io:
`{"level":"info","ts":1616107431.2710457,"caller":"service/service.go:151","msg":"initializing minio","bucket":"corteza-prod/system","endpoint":"minio:9000","error":"Bucket name contains invalid characters"}`

## Why it's a big deal

Google Cloud Storage (and probably all other S3 PaaS options out there) have globally unique bucket names, so the `system` bucket is unavailable. We need to use MINIO_BUCKET.

## Proposed fix
Use `${MINIO_BUCKET}-system` instead of `${MINIO_BUCKET}/system` as bucket names.

To repro the issue and test the fix you can use this simplified `docker-composer.yaml`:

```yaml
nginx-proxy:
  # HTTP reverse proxy
  image: jwilder/nginx-proxy:latest
  restart: unless-stopped
  ports:
    - "80:80"
  volumes:
    - /var/run/docker.sock:/tmp/docker.sock:ro

corteza:
  # Corteza Go Server
  image: cortezaproject/corteza-server:${CORTEZA_VERSION}
  restart: on-failure
  env_file: [ .env ]
  depends_on: [ cloudsql-proxy, corredor ]
  environment:
    HTTP_WEBAPP_ENABLED: 'true'
    DB_DSN: postgres://corteza:corteza@postgres:5432/corteza?sslmode=disable
    VIRTUAL_HOST: corteza.127.0.0.1.xip.io
    MINIO_ENDPOINT: minio:9000
    MINIO_SECURE: 'false'
    MINIO_ACCESS_KEY: corteza
    MINIO_SECRET_KEY: corteza
    MINIO_BUCKET: any_value_here_triggers_an_error

corredor:
  # Corteza Corredor Node.js Server
  image: cortezaproject/corteza-server-corredor:${CORTEZA_VERSION}
  restart: on-failure

minio:
  # S3 compatible storage
  image: minio/minio:latest
  restart: on-failure
  volumes:
    - ./service_account.json:/var/service_account.json:ro
  command: [ server, /data ]
  environment:
    MINIO_ROOT_USER: corteza
    MINIO_ROOT_PASSWORD: corteza
    VIRTUAL_HOST: minio.127.0.0.1.xip.io

postgres:
  # PostgreSQL Database Server
  image: postgres:13
  restart: on-failure
  healthcheck: { test: [CMD-SHELL, "pg_isready -U corteza"], interval: 10s, timeout: 5s, retries: 5 }
  environment:
    POSTGRES_USER: corteza
    POSTGRES_PASSWORD: corteza
```
