### PR TITLE
WF type tweaks

### DIFF
--- a/automation/automation/expr_types.go
+++ b/automation/automation/expr_types.go
@@ -2,6 +2,7 @@ package automation
 
 import (
 	"fmt"
+
 	"github.com/cortezaproject/corteza-server/pkg/expr"
 	"gopkg.in/mail.v2"
 )
@@ -23,6 +24,8 @@ func CastToEmailMessage(val interface{}) (out *emailMessage, err error) {
 		}
 
 		return val, nil
+	case nil:
+		return &emailMessage{msg: mail.NewMessage()}, nil
 	default:
 		return nil, fmt.Errorf("unable to cast type %T to %T", val, out)
 	}

--- a/compose/service/record.go
+++ b/compose/service/record.go
@@ -553,7 +553,7 @@ func RecordValueSanitization(m *types.Module, vv types.RecordValueSet) (err erro
 		}
 
 		if field.IsRef() {
-			if v.Value == "" {
+			if v.Value == "" || v.Value == "0" {
 				return nil
 			}
 

--- a/pkg/expr/expr_types.go
+++ b/pkg/expr/expr_types.go
@@ -339,6 +339,13 @@ func CastToDateTime(val interface{}) (out *time.Time, err error) {
 }
 
 func CastToFloat(val interface{}) (out float64, err error) {
+	switch val := val.(type) {
+	case nil:
+		return 0, nil
+	case *Float:
+		return val.value, nil
+	}
+
 	return cast.ToFloat64E(emptyStringFailsafe(val))
 }
 


### PR DESCRIPTION
# 1 Reference values

When assigning a missing value to a reference record value (record, user, file, ...), the sanitiser marked it as bad and failed.
This is a bit awkward to work with.

My solution makes the sanitiser ignore `"0"`'s (missing refs).
An alternative solution would be to filter these out within workflow when we cast to a `ComposeRecord`.
IMO either would do, your choice.

# 2 Zero values

Passing missing values and casting those causes wf to fail for some cases due to `nil`.
The modification to the code template prevents that by defining a fall back to the zero value of the type.
