### PR TITLE
Add endpoint to fetch available render drivers

### DIFF
--- a/system/renderer/generic_html.go
+++ b/system/renderer/generic_html.go
@@ -9,20 +9,47 @@ import (
 )
 
 type (
-	genericHTML       struct{}
+	genericHTML struct {
+		def DriverDefinition
+	}
 	genericHTMLDriver struct{}
 )
 
 func newGenericHTML() driverFactory {
-	return &genericHTML{}
+	return &genericHTML{
+		def: DriverDefinition{
+			Name: "genericHTML",
+			InputTypes: []types.DocumentType{
+				types.DocumentTypePlain,
+				types.DocumentTypeHTML,
+			},
+			OutputTypes: []types.DocumentType{
+				types.DocumentTypeHTML,
+			},
+		},
+	}
+}
+
+func (d *genericHTML) Define() DriverDefinition {
+	return d.def
 }
 
 func (d *genericHTML) CanRender(t types.DocumentType) bool {
-	return t == types.DocumentTypeHTML || t == types.DocumentTypePlain
+	for _, i := range d.def.InputTypes {
+		if i == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *genericHTML) CanProduce(t types.DocumentType) bool {
-	return t == types.DocumentTypeHTML
+	for _, o := range d.def.OutputTypes {
+		if o == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *genericHTML) Driver() driver {

--- a/system/renderer/generic_text.go
+++ b/system/renderer/generic_text.go
@@ -10,7 +10,9 @@ import (
 )
 
 type (
-	genericText       struct{}
+	genericText struct {
+		def DriverDefinition
+	}
 	genericTextDriver struct{}
 )
 
@@ -19,15 +21,40 @@ var (
 )
 
 func newGenericText() driverFactory {
-	return &genericText{}
+	return &genericText{
+		def: DriverDefinition{
+			Name: "genericText",
+			InputTypes: []types.DocumentType{
+				types.DocumentTypePlain,
+				types.DocumentTypeHTML,
+			},
+			OutputTypes: []types.DocumentType{
+				types.DocumentTypePlain,
+			},
+		},
+	}
+}
+
+func (d *genericText) Define() DriverDefinition {
+	return d.def
 }
 
 func (d *genericText) CanRender(t types.DocumentType) bool {
-	return t == types.DocumentTypePlain || t == types.DocumentTypeHTML
+	for _, i := range d.def.InputTypes {
+		if i == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *genericText) CanProduce(t types.DocumentType) bool {
-	return t == types.DocumentTypePlain
+	for _, o := range d.def.OutputTypes {
+		if o == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *genericText) Driver() driver {

--- a/system/renderer/gotenbergPDF.go
+++ b/system/renderer/gotenbergPDF.go
@@ -15,6 +15,7 @@ import (
 type (
 	gotenbergPDF struct {
 		url string
+		def DriverDefinition
 	}
 	gotenbergPDFDriver struct {
 		url string
@@ -25,15 +26,40 @@ type (
 func newGotenbergPDF(url string) driverFactory {
 	return &gotenbergPDF{
 		url: url,
+
+		def: DriverDefinition{
+			Name: "gotenbergPDF",
+			InputTypes: []types.DocumentType{
+				types.DocumentTypePlain,
+				types.DocumentTypeHTML,
+			},
+			OutputTypes: []types.DocumentType{
+				types.DocumentTypePDF,
+			},
+		},
 	}
 }
 
+func (d *gotenbergPDF) Define() DriverDefinition {
+	return d.def
+}
+
 func (d *gotenbergPDF) CanRender(t types.DocumentType) bool {
-	return t == types.DocumentTypeHTML || t == types.DocumentTypePlain
+	for _, i := range d.def.InputTypes {
+		if i == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *gotenbergPDF) CanProduce(t types.DocumentType) bool {
-	return t == types.DocumentTypePDF
+	for _, o := range d.def.OutputTypes {
+		if o == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *gotenbergPDF) Driver() driver {

--- a/system/renderer/renderer.go
+++ b/system/renderer/renderer.go
@@ -47,3 +47,11 @@ func (r *renderer) Render(ctx context.Context, pl *RendererPayload) (io.ReadSeek
 
 	return nil, errors.New("rendering failed: driver not found")
 }
+
+func (r *renderer) Drivers() []DriverDefinition {
+	dd := make([]DriverDefinition, len(r.factories))
+	for i, f := range r.factories {
+		dd[i] = f.Define()
+	}
+	return dd
+}

--- a/system/renderer/types.go
+++ b/system/renderer/types.go
@@ -39,7 +39,15 @@ type (
 		Name   string
 	}
 
+	DriverDefinition struct {
+		Name        string               `json:"name"`
+		InputTypes  []types.DocumentType `json:"inputTypes"`
+		OutputTypes []types.DocumentType `json:"outputTypes"`
+	}
+
 	driverFactory interface {
+		Define() DriverDefinition
+
 		CanRender(t types.DocumentType) bool
 		CanProduce(t types.DocumentType) bool
 		Driver() driver

--- a/system/rest.yaml
+++ b/system/rest.yaml
@@ -1343,6 +1343,10 @@ endpoints:
         type: uint64
         required: true
         title: Template ID
+  - name: renderDrivers
+    method: GET
+    title: Render drivers
+    path: "/render/drivers"
   - name: render
     method: POST
     title: Render template

--- a/system/rest/request/template.go
+++ b/system/rest/request/template.go
@@ -192,6 +192,9 @@ type (
 		TemplateID uint64 `json:",string"`
 	}
 
+	TemplateRenderDrivers struct {
+	}
+
 	TemplateRender struct {
 		// TemplateID PATH parameter
 		//
@@ -775,6 +778,22 @@ func (r *TemplateUndelete) Fill(req *http.Request) (err error) {
 		}
 
 	}
+
+	return err
+}
+
+// NewTemplateRenderDrivers request
+func NewTemplateRenderDrivers() *TemplateRenderDrivers {
+	return &TemplateRenderDrivers{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r TemplateRenderDrivers) Auditable() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+// Fill processes request and fills internal variables
+func (r *TemplateRenderDrivers) Fill(req *http.Request) (err error) {
 
 	return err
 }

--- a/system/service/template.go
+++ b/system/service/template.go
@@ -36,6 +36,7 @@ type (
 
 	rendererService interface {
 		Render(ctx context.Context, p *renderer.RendererPayload) (io.ReadSeeker, error)
+		Drivers() []renderer.DriverDefinition
 	}
 
 	TemplateService interface {
@@ -50,6 +51,7 @@ type (
 		DeleteByID(ctx context.Context, ID uint64) error
 		UndeleteByID(ctx context.Context, ID uint64) error
 
+		Drivers() []renderer.DriverDefinition
 		Render(ctx context.Context, templateID uint64, dstType string, variables map[string]interface{}, options map[string]string) (io.ReadSeeker, error)
 	}
 )
@@ -328,6 +330,10 @@ func (svc template) UndeleteByID(ctx context.Context, ID uint64) (err error) {
 	}()
 
 	return svc.recordAction(ctx, tplProps, TemplateActionUndelete, err)
+}
+
+func (svc template) Drivers() []renderer.DriverDefinition {
+	return svc.renderer.Drivers()
 }
 
 func (svc template) Render(ctx context.Context, templateID uint64, dstType string, variables map[string]interface{}, options map[string]string) (document io.ReadSeeker, err error) {


### PR DESCRIPTION
A simple `GET /api/system/template/render/drivers` endpoint that returns the definitions of the registered/available drivers.
Example response:

```
{
    "response": {
        "set": [
            {
                "name": "genericText",
                "inputTypes": [
                    "text/plain",
                    "text/html"
                ],
                "outputTypes": [
                    "text/plain"
                ]
            },
            {
                "name": "genericHTML",
                "inputTypes": [
                    "text/plain",
                    "text/html"
                ],
                "outputTypes": [
                    "text/html"
                ]
            }
        ]
    }
}
```

Ref ticket: Admin > templates > PDF preview returns error
