### PR TITLE
Adds expr functions for KV, KVV and Vars manipulation

### DIFF
--- a/automation/service/workflow.go
+++ b/automation/service/workflow.go
@@ -538,7 +538,7 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 		}()
 
 		// Start with workflow scope
-		scope := wf.Scope.Merge()
+		scope := wf.Scope.MustMerge()
 
 		ssp := types.SessionStartParams{
 			WorkflowID: wf.ID,
@@ -559,7 +559,7 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 			wap.setTrigger(t)
 
 			// Add trigger's input to scope
-			scope = scope.Merge(t.Input)
+			scope = scope.MustMerge(t.Input)
 			_ = scope.AssignFieldValue("eventType", expr.Must(expr.NewString(t.EventType)))
 			_ = scope.AssignFieldValue("resourceType", expr.Must(expr.NewString(t.ResourceType)))
 
@@ -572,7 +572,7 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 		}
 
 		// Finally, assign input values
-		ssp.Input = scope.Merge(p.Input)
+		ssp.Input = scope.MustMerge(p.Input)
 
 		if wf.RunAs > 0 {
 			if runAs, err = DefaultUser.FindByID(ctx, wf.RunAs); err != nil {
@@ -617,7 +617,7 @@ func makeWorkflowHandler(ac workflowExecController, s *session, t *types.Trigger
 
 		var (
 			// create session scope from predefined workflow scope and trigger input
-			scope   = wf.Scope.Merge(t.Input)
+			scope   = wf.Scope.MustMerge(t.Input)
 			evScope *expr.Vars
 			wait    WaitFn
 		)
@@ -627,7 +627,7 @@ func makeWorkflowHandler(ac workflowExecController, s *session, t *types.Trigger
 				return
 			}
 
-			scope = scope.Merge(evScope)
+			scope = scope.MustMerge(evScope)
 		}
 
 		_ = scope.AssignFieldValue("eventType", expr.Must(expr.NewString(ev.EventType())))

--- a/automation/service/workflow_converter.go
+++ b/automation/service/workflow_converter.go
@@ -450,7 +450,7 @@ func (svc workflowConverter) convPromptStep(s *types.WorkflowStep) (wfexec.Step,
 			return wfexec.Prompt(ownerId, s.Ref, payload), nil
 		}
 
-		results, err := res.Eval(ctx, r.Scope.Merge(r.Input))
+		results, err := res.Eval(ctx, r.Scope.MustMerge(r.Input))
 		if err != nil {
 			return nil, err
 		}

--- a/automation/types/expr.go
+++ b/automation/types/expr.go
@@ -87,7 +87,7 @@ func (set ExprSet) Validate(ctx context.Context, in *expr.Vars) (TestSet, error)
 		err error
 
 		// Copy/create scope
-		scope = (&expr.Vars{}).Merge(in)
+		scope = (&expr.Vars{}).MustMerge(in)
 	)
 
 	for _, e := range set {
@@ -108,7 +108,7 @@ func (set ExprSet) Eval(ctx context.Context, in *expr.Vars) (*expr.Vars, error) 
 		err error
 
 		// Copy input to scope
-		scope = (&expr.Vars{}).Merge(in)
+		scope = (&expr.Vars{}).MustMerge(in)
 
 		// Prepare output scope
 		out, _ = expr.NewVars(nil)
@@ -223,7 +223,7 @@ func ExpressionsStep(ee ...*Expr) *expressionsStep {
 }
 
 func (s expressionsStep) Exec(ctx context.Context, r *wfexec.ExecRequest) (wfexec.ExecResponse, error) {
-	result, err := s.Set.Eval(ctx, r.Scope.Merge(r.Input))
+	result, err := s.Set.Eval(ctx, r.Scope.MustMerge(r.Input))
 	if err != nil {
 		return nil, err
 	}

--- a/automation/types/function.go
+++ b/automation/types/function.go
@@ -98,7 +98,7 @@ func (f functionStep) Exec(ctx context.Context, r *wfexec.ExecRequest) (wfexec.E
 	if len(f.arguments) > 0 {
 		// Arguments defined, get values from scope and use them when calling
 		// function/handler
-		args, err = f.arguments.Eval(ctx, r.Scope.Merge(r.Input))
+		args, err = f.arguments.Eval(ctx, r.Scope.MustMerge(r.Input))
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +171,7 @@ func (f *iteratorStep) Exec(ctx context.Context, r *wfexec.ExecRequest) (wfexec.
 	if len(f.arguments) > 0 {
 		// Arguments defined, get values from scope and use them when calling
 		// iterator/handler
-		args, err = f.arguments.Eval(ctx, r.Scope.Merge(r.Input))
+		args, err = f.arguments.Eval(ctx, r.Scope.MustMerge(r.Input))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/expr/func_json.go
+++ b/pkg/expr/func_json.go
@@ -1,0 +1,18 @@
+package expr
+
+import (
+	"encoding/json"
+	"github.com/PaesslerAG/gval"
+)
+
+func JsonFunctions() []gval.Language {
+	return []gval.Language{
+		// TODO: Json decoding, parsing, stringify, JQ, JSONPath
+		gval.Function("toJSON", toJSON),
+	}
+}
+
+func toJSON(f interface{}) string {
+	b, _ := json.Marshal(f)
+	return string(b)
+}

--- a/pkg/expr/func_json_test.go
+++ b/pkg/expr/func_json_test.go
@@ -1,0 +1,19 @@
+package expr
+
+func Example_toJSON() {
+	var (
+		p = map[string]interface{}{
+			"vars": Must(NewVars(
+				&Vars{value: map[string]TypedValue{
+					"k1": &String{value: "v1"},
+					"k2": &String{value: "v2"},
+				}},
+			)),
+		}
+	)
+
+	eval(`toJSON(vars)`, p)
+
+	// output:
+	// {"k1":{"@value":"v1","@type":"String"},"k2":{"@value":"v2","@type":"String"}}
+}

--- a/pkg/expr/func_str.go
+++ b/pkg/expr/func_str.go
@@ -83,7 +83,7 @@ func join(arr interface{}, sep string) (out string, err error) {
 	} else if i, is := arr.([]interface{}); is {
 		// If slice of interfaces, we can try to cast them
 		var aux []string
-		aux, err = CastStringSlice(i)
+		aux, err = CastToStringSlice(i)
 		if err != nil {
 			return
 		}

--- a/pkg/expr/parser.go
+++ b/pkg/expr/parser.go
@@ -87,9 +87,11 @@ func AllFunctions() []gval.Language {
 
 	//ff = append(ff, GenericFunctions()...)
 	ff = append(ff, StringFunctions()...)
+	ff = append(ff, JsonFunctions()...)
 	ff = append(ff, NumericFunctions()...)
 	ff = append(ff, TimeFunctions()...)
 	ff = append(ff, ArrayFunctions()...)
+	ff = append(ff, KvFunctions()...)
 
 	return ff
 }

--- a/pkg/expr/vars_test.go
+++ b/pkg/expr/vars_test.go
@@ -2,11 +2,84 @@ package expr
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 // extract typed-value
+
+func Example_set_vars() {
+	var (
+		p = map[string]interface{}{
+			"vars":  &Vars{},
+			"key":   "foo",
+			"value": &String{value: "foo"},
+		}
+	)
+
+	eval(`toJSON(set(vars, key, value))`, p)
+
+	// output:
+	// {"foo":{"@value":"foo","@type":"String"}}
+}
+
+func Example_merge_vars() {
+	var (
+		p = map[string]interface{}{
+			"vars": &Vars{},
+			"foo": &Vars{value: map[string]TypedValue{
+				"k1": &String{value: "v1"},
+			}},
+			"bar": &Vars{value: map[string]TypedValue{
+				"k2": &String{value: "v2"},
+			}},
+		}
+	)
+
+	eval(`toJSON(merge(foo, bar))`, p)
+
+	// output:
+	// {"k1":{"@value":"v1","@type":"String"},"k2":{"@value":"v2","@type":"String"}}
+}
+
+func Example_filter_vars() {
+	var (
+		p = map[string]interface{}{
+			"vars": &Vars{value: map[string]TypedValue{
+				"k1": &String{value: "v1"},
+				"k5": &String{value: "v5"},
+			}},
+			"key1": "k1",
+			"key2": "k3",
+			"key3": "k5",
+		}
+	)
+
+	eval(`toJSON(filter(vars, key1, key2, key3))`, p)
+
+	// output:
+	// {"k1":{"@value":"v1","@type":"String"},"k5":{"@value":"v5","@type":"String"}}
+}
+
+func Example_omit_vars() {
+	var (
+		p = map[string]interface{}{
+			"vars": &Vars{value: map[string]TypedValue{
+				"k1": &String{value: "v1"},
+				"k2": &String{value: "v2"},
+				"k3": &String{value: "v3"},
+			}},
+			"key1": "k1",
+			"key2": "k3",
+		}
+	)
+
+	eval(`toJSON(omit(vars, key1, key2))`, p)
+
+	// output:
+	// {"k2":{"@value":"v2","@type":"String"}}
+}
 
 func TestVars_Decode(t *testing.T) {
 	t.Run("mix", func(t *testing.T) {
@@ -107,6 +180,112 @@ func TestVars_Assign(t *testing.T) {
 	req.NoError(Assign(vars, "foo", &String{value: "foo"}))
 	req.NoError(Assign(vars, "vars", &Vars{}))
 	req.NoError(Assign(vars, "vars.foo", &String{value: "foo"}))
+
+	fmt.Println("Vars: ", vars)
+}
+
+func TestVars_Set(t *testing.T) {
+	var (
+		req = require.New(t)
+
+		vars = &Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+			"k2": &String{value: "v2"},
+		}}
+	)
+
+	out, err := set(vars, "k1", &String{value: "v11"})
+	fmt.Println("Out: ", out)
+	req.NoError(err)
+	req.Equal(&String{value: "v11"}, out.(*Vars).GetValue()["k1"])
+
+	// Making sure empty vars updates without error
+	vars = &Vars{}
+	out, err = set(vars, "k2", &Array{value: []TypedValue{&String{value: "foo"}, &String{value: "bar"}}})
+	req.NoError(err)
+	req.Equal(&Array{value: []TypedValue{&String{value: "foo"}, &String{value: "bar"}}}, out.(*Vars).GetValue()["k2"])
+}
+
+func TestVars_MergeVars(t *testing.T) {
+	var (
+		req = require.New(t)
+
+		vars Vars
+		foo  = Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+		}}
+		bar = Vars{value: map[string]TypedValue{
+			"k2": &String{value: "v2"},
+		}}
+		expected = &Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+			"k2": &String{value: "v2"},
+		}}
+	)
+
+	fmt.Println("vars: ", vars)
+	out := vars.MustMerge(&foo, &bar)
+	fmt.Println("vars: ", out)
+	req.Equal(expected, out)
+}
+
+func TestVars_Merge(t *testing.T) {
+	var (
+		req = require.New(t)
+
+		vars = &Vars{}
+		foo  = &Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+		}}
+		bar = &Vars{value: map[string]TypedValue{
+			"k2": &String{value: "v2"},
+		}}
+		expected = &Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+			"k2": &String{value: "v2"},
+		}}
+	)
+
+	out, err := merge(vars, foo, bar)
+	req.NoError(err)
+	req.Equal(expected, out)
+}
+
+func TestVars_Filter(t *testing.T) {
+	var (
+		req = require.New(t)
+
+		vars = &Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+			"k2": &String{value: "v2"},
+		}}
+		expected = &Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+		}}
+	)
+
+	out, err := filter(vars, "k1", "k3")
+	req.NoError(err)
+	req.Equal(expected, out)
+}
+
+func TestVars_Omit(t *testing.T) {
+	var (
+		req = require.New(t)
+
+		vars = Vars{value: map[string]TypedValue{
+			"k1": &String{value: "v1"},
+			"k2": &String{value: "v2"},
+			"k3": &String{value: "v3"},
+		}}
+		expected = &Vars{value: map[string]TypedValue{
+			"k2": &String{value: "v2"},
+		}}
+	)
+
+	out, err := omit(&vars, "k1", "k3")
+	req.NoError(err)
+	req.Equal(expected, out)
 }
 
 func TestVars_UnmarshalJSON(t *testing.T) {

--- a/pkg/wfexec/gateways.go
+++ b/pkg/wfexec/gateways.go
@@ -66,7 +66,7 @@ func (gw *joinGateway) Exec(_ context.Context, r *ExecRequest) (ExecResponse, er
 	var merged *expr.Vars
 	for _, p := range gw.paths {
 		if gw.scopes[p] != nil {
-			merged = merged.Merge(gw.scopes[p])
+			merged = merged.MustMerge(gw.scopes[p])
 		}
 	}
 

--- a/pkg/wfexec/session.go
+++ b/pkg/wfexec/session.go
@@ -418,7 +418,7 @@ func (s *Session) worker(ctx context.Context) {
 				defer s.mux.Unlock()
 
 				// making sure result != nil
-				s.result = (&expr.Vars{}).Merge(st.scope)
+				s.result = (&expr.Vars{}).MustMerge(st.scope)
 
 				// Call event handler with completed status
 				s.eventHandler(SessionCompleted, st, s)
@@ -549,7 +549,7 @@ func (s *Session) exec(ctx context.Context, st *State) (err error) {
 
 	var (
 		result ExecResponse
-		scope  = (&expr.Vars{}).Merge(st.scope)
+		scope  = (&expr.Vars{}).MustMerge(st.scope)
 
 		currLoop = st.loopCurr()
 
@@ -635,7 +635,7 @@ func (s *Session) exec(ctx context.Context, st *State) (err error) {
 			// most common (successful) result
 			// session will continue with configured child steps
 			st.results = result
-			scope = scope.Merge(st.results)
+			scope = scope.MustMerge(st.results)
 
 		case *errHandler:
 			st.action = "error handler initialized"


### PR DESCRIPTION
Adds expr functions for KV, KVV, Vars manipulation

- Adds/Refactors methods for Set, Merge, Filter, Delete
- Renames expr/Vars.Merge to MustMerge, updates its usage
- Appends kvFunctions to parser in pkg/expr
- Update/Fixes tests and example testable

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
