### PR TITLE
Prevent error handling from ending the WF exec session

### DIFF
--- a/automation/service/session.go
+++ b/automation/service/session.go
@@ -171,7 +171,9 @@ func (svc *session) Start(g *wfexec.Graph, i auth.Identifiable, ssp types.Sessio
 			return nil, errors.InvalidData("cannot start workflow session multiple starting steps found")
 		}
 	} else if start = g.StepByID(ssp.StepID); start == nil {
-		return nil, errors.InvalidData("trigger staring step references nonexisting step")
+		return nil, errors.InvalidData("trigger staring step references non-existing step")
+	} else if len(g.Parents(g.StepByID(ssp.StepID))) > 0 {
+		return nil, errors.InvalidData("cannot start workflow on a step with parents")
 	}
 
 	var (

--- a/automation/service/session.go
+++ b/automation/service/session.go
@@ -300,7 +300,7 @@ func (svc *session) gc() {
 			pending1d++
 		}
 
-		if s.CompletedAt == nil {
+		if !s.GC() {
 			continue
 		}
 

--- a/automation/service/session_test.go
+++ b/automation/service/session_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/cortezaproject/corteza-server/automation/types"
+	"github.com/cortezaproject/corteza-server/pkg/wfexec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSession_Start(t *testing.T) {
+	var (
+		req = require.New(t)
+		ses = &session{}
+		g   = wfexec.NewGraph()
+		err error
+	)
+
+	_, err = ses.Start(g, nil, types.SessionStartParams{})
+	req.EqualError(err, "could not find starting step")
+
+	g.AddStep(wfexec.NewGenericStep(nil))
+	_, err = ses.Start(g, nil, types.SessionStartParams{StepID: 4321})
+	req.EqualError(err, "trigger staring step references non-existing step")
+
+	// Adding another orphaned step and starting session w/o explicitly specifying the starting step
+	g.AddStep(wfexec.NewGenericStep(nil))
+	_, err = ses.Start(g, nil, types.SessionStartParams{})
+	req.EqualError(err, "cannot start workflow session multiple starting steps found")
+
+	// add a generic step with a known ID so we can use it as a starting point
+	s := wfexec.NewGenericStep(nil)
+	s.SetID(42)
+	g.AddStep(s)
+	// add parents to the 42 step
+	g.AddStep(wfexec.NewGenericStep(nil), s)
+	_, err = ses.Start(g, nil, types.SessionStartParams{StepID: 42})
+	req.EqualError(err, "cannot start workflow on a step with parents")
+
+}

--- a/automation/types/session.go
+++ b/automation/types/session.go
@@ -114,6 +114,10 @@ func (s Session) PendingPrompts(ownerId uint64) []*wfexec.PendingPrompt {
 	return s.session.PendingPrompts(ownerId)
 }
 
+func (s Session) GC() bool {
+	return s.CompletedAt != nil || s.session.Error() != nil
+}
+
 // Wait blocks until workflow session is completed or fails (or context is canceled) and returns resuts
 func (s *Session) WaitResults(ctx context.Context) (*expr.Vars, wfexec.SessionStatus, Stacktrace, error) {
 	if err := s.session.WaitUntil(ctx, wfexec.SessionFailed, wfexec.SessionCompleted); err != nil {

--- a/pkg/wfexec/session.go
+++ b/pkg/wfexec/session.go
@@ -442,7 +442,7 @@ func (s *Session) worker(ctx context.Context) {
 					defer s.mux.Unlock()
 
 					// when the err handler is defined, the error was handled and should not kill the workflow
-					if !st.handled {
+					if !st.errHandled {
 						// We need to force failed session status
 						// because it's not set early enough to pick it up with s.Status()
 						status = SessionFailed
@@ -594,7 +594,7 @@ func (s *Session) exec(ctx context.Context, st *State) (err error) {
 			// in case of another error in the error-handling branch
 			eh := st.errHandler
 			st.errHandler = nil
-			st.handled = true
+			st.errHandled = true
 			if err = s.enqueue(ctx, st.Next(eh, scope)); err != nil {
 				log.Warn("unable to queue", zap.Error(err))
 			}

--- a/pkg/wfexec/session.go
+++ b/pkg/wfexec/session.go
@@ -252,6 +252,8 @@ func (s *Session) Exec(ctx context.Context, step Step, scope *expr.Vars) error {
 	}()
 
 	if err != nil {
+		// send nil to error queue to trigger worker shutdown
+		// session error must be set to update session status
 		s.qErr <- err
 		return err
 	}
@@ -400,7 +402,6 @@ func (s *Session) worker(ctx context.Context) {
 			s.queueScheduledSuspended()
 
 		case st := <-s.qState:
-			// @todo !!
 			if st == nil {
 				// stop worker
 				s.log.Debug("completed")

--- a/pkg/wfexec/session_test.go
+++ b/pkg/wfexec/session_test.go
@@ -255,6 +255,25 @@ func TestSession_ErrHandler(t *testing.T) {
 	)
 }
 
+func TestSession_ExecStepWithParents(t *testing.T) {
+	var (
+		ctx = context.Background()
+		req = require.New(t)
+		wf  = NewGraph()
+		ses = NewSession(ctx, wf)
+
+		p = &sesTestStep{name: "p"}
+		c = &sesTestStep{name: "c"}
+	)
+
+	wf.AddStep(p, c)
+
+	req.Equal(SessionActive, ses.Status())
+	req.Error(ses.Exec(ctx, c, nil))
+	req.Error(ses.Wait(ctx))
+	req.Equal(SessionFailed, ses.Status())
+}
+
 func bmSessionSimpleStepSequence(c uint64, b *testing.B) {
 	var (
 		ctx = context.Background()

--- a/pkg/wfexec/state.go
+++ b/pkg/wfexec/state.go
@@ -46,6 +46,7 @@ type (
 
 		// error handling step
 		errHandler Step
+		handled    bool
 
 		loops []Iterator
 

--- a/pkg/wfexec/state.go
+++ b/pkg/wfexec/state.go
@@ -2,9 +2,10 @@ package wfexec
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/cortezaproject/corteza-server/pkg/auth"
 	"github.com/cortezaproject/corteza-server/pkg/expr"
-	"time"
 )
 
 type (
@@ -46,7 +47,9 @@ type (
 
 		// error handling step
 		errHandler Step
-		handled    bool
+
+		// error handled flag, this gets restarted on every new state!
+		errHandled bool
 
 		loops []Iterator
 


### PR DESCRIPTION
(`2021.3.x`, `2021.6.x`)

When the worker finished with the step execution, it only checked if the error was set and not if the error was handled.
This fixes it and it worked for my test cases; please check it out if I've missed anything.