### PR TITLE
Fix field access control for default values

### DIFF
--- a/compose/service/record_test.go
+++ b/compose/service/record_test.go
@@ -84,7 +84,7 @@ func TestDefaultValueSetting(t *testing.T) {
 		}
 	)
 
-	out := RecordValueDefaults(mod, nil)
+	out := RecordValueDefaults(context.Background(), nil, mod, nil)
 	chk(out, "single", 0, "s")
 	chk(out, "multi", 0, "m1")
 	chk(out, "multi", 1, "m2")


### PR DESCRIPTION
If a module field defined a default value and RBAC rules that denied some user from creating a specific field; any create/update requests would fail, because the field contained some value (the default).

This fix ignores default values for fields where the user doesn't have access.
I think this solution is completely valid; if the field with a default value needs to be populated, it should be marked as required.

Another solution would be to assign the defaults after all the AC and such is ran.
I am not so sure how well such an approach would hold.

**todo** tests