### PR TITLE
Encode stripped html special chars

### DIFF
--- a/compose/service/values/sanitizer.go
+++ b/compose/service/values/sanitizer.go
@@ -2,6 +2,7 @@ package values
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strconv"
 	"strings"
@@ -294,8 +295,14 @@ func sString(str string) string {
 	// match only colors for html editor elements on style attr
 	p.AllowAttrs("style").OnElements("span", "p")
 	p.AllowStyles("color").Matching(regexp.MustCompile("(?i)^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$")).Globally()
+	p.AllowStyles("background-color").Matching(regexp.MustCompile("(?i)^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$")).Globally()
 
-	return p.Sanitize(str)
+	sanitized := p.Sanitize(str)
+
+	// handle escaped strings and unescape them
+	// all the dangerous chars should have been stripped
+	// by now
+	return html.UnescapeString(sanitized)
 }
 
 // sanitize casts value to field kind format

--- a/compose/service/values/sanitizer_test.go
+++ b/compose/service/values/sanitizer_test.go
@@ -187,7 +187,14 @@ func Test_sanitizer_Run(t *testing.T) {
 			kind:    "String",
 			options: map[string]interface{}{},
 			input:   `<script>document.write("<scri");</script>pt src="https://cortezaproject.org/script.js"></script>`,
-			output:  "pt src=&#34;https://cortezaproject.org/script.js&#34;&gt;",
+			output:  `pt src="https://cortezaproject.org/script.js">`,
+		},
+		{
+			name:    "string escaping; inline styles unchanged",
+			kind:    "String",
+			options: map[string]interface{}{},
+			input:   `<span style="background-color: #00ff00"><span style="color: #4a86e8">nasty looking content</span></span>`,
+			output:  `<span style="background-color: #00ff00"><span style="color: #4a86e8">nasty looking content</span></span>`,
 		},
 		{
 			name:    "string escaping; script with a",
@@ -299,7 +306,7 @@ func Test_sanitizer_Run(t *testing.T) {
 			kind:    "String",
 			options: map[string]interface{}{},
 			input:   `'';!--"<XSS>=&{()}`,
-			output:  "&#39;&#39;;!--&#34;=&amp;{()}",
+			output:  `'';!--"=&{()}`,
 		},
 		{
 			name:    "string escaping; xss element",
@@ -314,6 +321,13 @@ func Test_sanitizer_Run(t *testing.T) {
 			options: map[string]interface{}{},
 			input:   `<tag1>cor<tag2></tag2>teza</tag1><tag1>server</tag1><tag2>123</tag2>`,
 			output:  "cortezaserver123",
+		},
+		{
+			name:    "string escaping; preserve necessary chars",
+			kind:    "String",
+			options: map[string]interface{}{},
+			input:   `a < b ; "'"`,
+			output:  `a < b ; "'"`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
What:
 - adds another html encoding after all the sanitizing is done, so we do not decode too much (keep some chars intact)
 - enable background-color also in rte