### PR TITLE
Fix deferred workflow execution

### DIFF
--- a/automation/service/service.go
+++ b/automation/service/service.go
@@ -30,7 +30,7 @@ type (
 	}
 
 	userService interface {
-		FindByID(ctx context.Context, userID uint64) (*types.User, error)
+		FindByAny(ctx context.Context, identifier interface{}) (*types.User, error)
 	}
 )
 

--- a/automation/service/trigger.go
+++ b/automation/service/trigger.go
@@ -465,7 +465,7 @@ func (svc *trigger) registerWorkflow(ctx context.Context, wf *types.Workflow, tt
 	}
 
 	if wf.RunAs > 0 {
-		if runAs, err = DefaultUser.FindByID(ctx, wf.RunAs); err != nil {
+		if runAs, err = DefaultUser.FindByAny(ctx, wf.RunAs); err != nil {
 			return fmt.Errorf("failed to load run-as user %d: %w", wf.RunAs, err)
 		} else if !runAs.Valid() {
 			return fmt.Errorf("invalid user %d used for workflow run-as", wf.RunAs)

--- a/automation/service/workflow.go
+++ b/automation/service/workflow.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/cortezaproject/corteza-server/pkg/options"
-
 	"github.com/cortezaproject/corteza-server/automation/types"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
 	intAuth "github.com/cortezaproject/corteza-server/pkg/auth"
@@ -16,6 +14,7 @@ import (
 	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/handle"
 	"github.com/cortezaproject/corteza-server/pkg/label"
+	"github.com/cortezaproject/corteza-server/pkg/options"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	"github.com/cortezaproject/corteza-server/pkg/wfexec"
 	"github.com/cortezaproject/corteza-server/store"
@@ -589,7 +588,7 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 		ssp.Input = scope.Merge(p.Input)
 
 		if wf.RunAs > 0 {
-			if runAs, err = DefaultUser.FindByID(ctx, wf.RunAs); err != nil {
+			if runAs, err = DefaultUser.FindByAny(ctx, wf.RunAs); err != nil {
 				return
 			}
 		}
@@ -623,12 +622,8 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 	return results, stacktrace, svc.recordAction(ctx, wap, WorkflowActionExecute, err)
 }
 
-func makeWorkflowHandler(ac workflowExecController, s *session, t *types.Trigger, wf *types.Workflow, g *wfexec.Graph, runAs intAuth.Identifiable) eventbus.HandlerFn {
+func makeWorkflowHandler(ac workflowExecController, s *session, t *types.Trigger, wf *types.Workflow, g *wfexec.Graph, _runAs intAuth.Identifiable) eventbus.HandlerFn {
 	return func(ctx context.Context, ev eventbus.Event) (err error) {
-		if !ac.CanExecuteWorkflow(ctx, wf) {
-			return WorkflowErrNotAllowedToExecute()
-		}
-
 		var (
 			// create session scope from predefined workflow scope and trigger input
 			scope   = wf.Scope.Merge(t.Input)
@@ -637,7 +632,7 @@ func makeWorkflowHandler(ac workflowExecController, s *session, t *types.Trigger
 
 			// The returned closure needs to have its own instance, so it doesn't
 			// affect the instance bound to the workflow handler
-			runAs = runAs
+			runAs = _runAs
 		)
 
 		if enc, is := ev.(varsEncoder); is {
@@ -657,6 +652,15 @@ func makeWorkflowHandler(ac workflowExecController, s *session, t *types.Trigger
 			//         - use http auth header and get username
 			//         - use from/to/replyTo and use that as an identifier
 			runAs = intAuth.GetIdentityFromContext(ctx)
+		} else {
+			// Running workflow with a different security context
+			ctx = intAuth.SetIdentityToContext(ctx, runAs)
+		}
+
+		// User (either invoker or one set in the security descriptor) MUST have
+		// permissions to execute this workflow
+		if !ac.CanExecuteWorkflow(ctx, wf) {
+			return WorkflowErrNotAllowedToExecute()
 		}
 
 		callStack := wfexec.GetContextCallStack(ctx)

--- a/pkg/scheduler/helpers.go
+++ b/pkg/scheduler/helpers.go
@@ -3,14 +3,17 @@ package scheduler
 import (
 	"time"
 
+	"github.com/cortezaproject/corteza-server/pkg/logger"
 	"github.com/getsentry/sentry-go"
 	"github.com/gorhill/cronexpr"
+	"go.uber.org/zap"
 )
 
 // OnInterval parses all given strings as crontab expressions (ii) and returns true if any of them matches current time
 func OnInterval(ii ...string) bool {
 	match, err := onInterval(now(), ii...)
 	if err != nil {
+		logger.Default().Error("failed to parse interval value", zap.Strings("value", ii), zap.Error(err))
 		sentry.CaptureException(err)
 	}
 	return match
@@ -44,6 +47,7 @@ func onInterval(now time.Time, ii ...string) (bool, error) {
 func OnTimestamp(tt ...string) bool {
 	match, err := onTimestamp(now(), tt...)
 	if err != nil {
+		logger.Default().Error("failed to parse timestamp value", zap.Strings("value", tt), zap.Error(err))
 		sentry.CaptureException(err)
 	}
 	return match


### PR DESCRIPTION
This fix addresses execution of deferred workflows
and access control when setting run-as user.

Some additional standardisation on how we write
mutex/lock code.


This will also be ported to `2021.9.x`.