### PR TITLE
2021.3.x non OIDC missing fix

### DIFF
--- a/app/boot_levels.go
+++ b/app/boot_levels.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	authService "github.com/cortezaproject/corteza-server/auth"
-	"github.com/cortezaproject/corteza-server/auth/external"
 	authSettings "github.com/cortezaproject/corteza-server/auth/settings"
 	autService "github.com/cortezaproject/corteza-server/automation/service"
 	cmpService "github.com/cortezaproject/corteza-server/compose/service"
@@ -414,51 +413,37 @@ func (app *CortezaApp) Activate(ctx context.Context) (err error) {
 }
 
 func updateAuthSettings(svc authServicer, current *types.AppSettings) {
-	var (
-		// current auth settings
-		cas       = current.Auth
-		providers []authSettings.Provider
-	)
-
-	for _, p := range cas.External.Providers {
-		if !p.Enabled || p.Handle == "" || p.Key == "" || p.Secret == "" {
-			continue
-		}
-
-		if strings.HasPrefix(p.Handle, external.OIDC_PROVIDER_PREFIX) {
-			if p.IssuerUrl == "" {
-				// OIDC IdPs need to have issuer URL
-				continue
-			}
-		} else {
-			// non-OIDC provider do not need issuer URL
-			p.IssuerUrl = ""
-		}
-
-		providers = append(providers, authSettings.Provider{
-			Handle:      p.Handle,
-			Label:       p.Label,
-			IssuerUrl:   p.IssuerUrl,
-			Key:         p.Key,
-			RedirectUrl: p.RedirectUrl,
-			Secret:      p.Secret,
-		})
-	}
-
 	as := &authSettings.Settings{
-		LocalEnabled:              cas.Internal.Enabled,
-		SignupEnabled:             cas.Internal.Signup.Enabled,
-		EmailConfirmationRequired: cas.Internal.Signup.EmailConfirmationRequired,
-		PasswordResetEnabled:      cas.Internal.PasswordReset.Enabled,
-		ExternalEnabled:           cas.External.Enabled,
-		Providers:                 providers,
+		LocalEnabled:              current.Auth.Internal.Enabled,
+		SignupEnabled:             current.Auth.Internal.Signup.Enabled,
+		EmailConfirmationRequired: current.Auth.Internal.Signup.EmailConfirmationRequired,
+		PasswordResetEnabled:      current.Auth.Internal.PasswordReset.Enabled,
+		ExternalEnabled:           current.Auth.External.Enabled,
+		MultiFactor: authSettings.MultiFactor{
+			TOTP: authSettings.TOTP{
+				Enabled:  current.Auth.MultiFactor.TOTP.Enabled,
+				Enforced: current.Auth.MultiFactor.TOTP.Enforced,
+				Issuer:   current.Auth.MultiFactor.TOTP.Issuer,
+			},
+			EmailOTP: authSettings.EmailOTP{
+				Enabled:  current.Auth.MultiFactor.EmailOTP.Enabled,
+				Enforced: current.Auth.MultiFactor.EmailOTP.Enforced,
+			},
+		},
 	}
 
-	as.MultiFactor.TOTP.Enabled = cas.MultiFactor.TOTP.Enabled
-	as.MultiFactor.TOTP.Enforced = cas.MultiFactor.TOTP.Enforced
-	as.MultiFactor.TOTP.Issuer = cas.MultiFactor.TOTP.Issuer
-	as.MultiFactor.EmailOTP.Enabled = cas.MultiFactor.EmailOTP.Enabled
-	as.MultiFactor.EmailOTP.Enforced = cas.MultiFactor.EmailOTP.Enforced
+	for _, p := range current.Auth.External.Providers {
+		if p.ValidConfiguration() {
+			as.Providers = append(as.Providers, authSettings.Provider{
+				Handle:      p.Handle,
+				Label:       p.Label,
+				IssuerUrl:   p.IssuerUrl,
+				Key:         p.Key,
+				RedirectUrl: p.RedirectUrl,
+				Secret:      p.Secret,
+			})
+		}
+	}
 
 	svc.UpdateSettings(as)
 }

--- a/app/boot_levels_test.go
+++ b/app/boot_levels_test.go
@@ -70,11 +70,10 @@ func Test_updateAuthSettings(t *testing.T) {
 						Secret:    "sec",
 					},
 					{ // add (w/o issuer)
-						Enabled:   true,
-						Handle:    "google",
-						IssuerUrl: "issuer",
-						Key:       "key",
-						Secret:    "sec",
+						Enabled: true,
+						Handle:  "google",
+						Key:     "key",
+						Secret:  "sec",
 					},
 					{ // add
 						Enabled: true,

--- a/auth/external/external.go
+++ b/auth/external/external.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	OIDC_PROVIDER_PREFIX = "openid-connect."
+	OIDC_PROVIDER_PREFIX = "openid-connect." // must match const in "github.com/cortezaproject/corteza-server/system/types" app_settings.go
+
 )
 
 func Init(store sessions.Store) {

--- a/auth/settings/settings.go
+++ b/auth/settings/settings.go
@@ -8,27 +8,31 @@ type (
 		PasswordResetEnabled      bool
 		ExternalEnabled           bool
 		Providers                 []Provider
+		MultiFactor               MultiFactor
+	}
 
-		MultiFactor struct {
-			EmailOTP struct {
-				// Can users use email for MFA
-				Enabled bool
+	MultiFactor struct {
+		EmailOTP EmailOTP
+		TOTP     TOTP
+	}
 
-				// Is MFA with email enforced?
-				Enforced bool
-			}
+	EmailOTP struct {
+		// Can users use email for MFA
+		Enabled bool
 
-			TOTP struct {
-				// Can users use TOTP MFA?
-				Enabled bool
+		// Is MFA with email enforced?
+		Enforced bool
+	}
 
-				// Is TOTP MFA enforced?
-				Enforced bool
+	TOTP struct {
+		// Can users use TOTP MFA?
+		Enabled bool
 
-				// TOTP issuer
-				Issuer string
-			}
-		}
+		// Is TOTP MFA enforced?
+		Enforced bool
+
+		// TOTP issuer
+		Issuer string
 	}
 
 	Provider struct {

--- a/system/types/app_settings_test.go
+++ b/system/types/app_settings_test.go
@@ -1,13 +1,29 @@
 package types
 
 import (
-	sqlTypes "github.com/jmoiron/sqlx/types"
-	"github.com/stretchr/testify/require"
 	"sort"
 	"testing"
+
+	sqlTypes "github.com/jmoiron/sqlx/types"
+	"github.com/stretchr/testify/require"
 )
 
 // 	Hello! This file is auto-generated.
+
+func Test_settingsExtAuthProvidersValidConfiguration(t *testing.T) {
+
+	var (
+		empty        = ExternalAuthProvider{}
+		google       = ExternalAuthProvider{Enabled: true, Handle: "google", Key: "some-guid", Secret: "s3cret"}
+		noIssuerOIDC = ExternalAuthProvider{Enabled: true, Handle: "openid-connect.bar", Key: "some-guid", Secret: "s3cret"}
+		goodOIDC     = ExternalAuthProvider{Enabled: true, Handle: "openid-connect.bar", Key: "some-guid", Secret: "s3cret", IssuerUrl: "https://example.org"}
+	)
+
+	require.False(t, noIssuerOIDC.ValidConfiguration())
+	require.True(t, goodOIDC.ValidConfiguration())
+	require.False(t, empty.ValidConfiguration())
+	require.True(t, google.ValidConfiguration())
+}
 
 func Test_settingsExtAuthProvidersDecode(t *testing.T) {
 	type (


### PR DESCRIPTION
I did some other refactoring to use a common constant for the prefix and moved the logic for checking if the provider is valid into types.

I did a bit of cleaning on updateAuthSettings to initialise rather than assign.

I was beaten to the update by 2 mins and didn't have tests.

Feel free to reject this PR or copy useful bits.