### PR TITLE
Add config validator and test for external auth provider

### DIFF
--- a/app/boot_levels_test.go
+++ b/app/boot_levels_test.go
@@ -70,11 +70,10 @@ func Test_updateAuthSettings(t *testing.T) {
 						Secret:    "sec",
 					},
 					{ // add (w/o issuer)
-						Enabled:   true,
-						Handle:    "google",
-						IssuerUrl: "issuer",
-						Key:       "key",
-						Secret:    "sec",
+						Enabled: true,
+						Handle:  "google",
+						Key:     "key",
+						Secret:  "sec",
 					},
 					{ // add
 						Enabled: true,

--- a/auth/external/external.go
+++ b/auth/external/external.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	OIDC_PROVIDER_PREFIX = "openid-connect."
+	OIDC_PROVIDER_PREFIX = "openid-connect." // must match const in "github.com/cortezaproject/corteza-server/system/types" app_settings.go
+
 )
 
 func Init(store sessions.Store) {

--- a/auth/settings/settings.go
+++ b/auth/settings/settings.go
@@ -8,6 +8,7 @@ type (
 		PasswordResetEnabled      bool
 		ExternalEnabled           bool
 		Providers                 []Provider
+		MultiFactor               MultiFactor
 
 		Saml struct {
 			Enabled bool
@@ -29,27 +30,30 @@ type (
 				IdentIdentifier string
 			}
 		}
+	}
 
-		MultiFactor struct {
-			EmailOTP struct {
-				// Can users use email for MFA
-				Enabled bool
+	MultiFactor struct {
+		EmailOTP EmailOTP
+		TOTP     TOTP
+	}
 
-				// Is MFA with email enforced?
-				Enforced bool
-			}
+	EmailOTP struct {
+		// Can users use email for MFA
+		Enabled bool
 
-			TOTP struct {
-				// Can users use TOTP MFA?
-				Enabled bool
+		// Is MFA with email enforced?
+		Enforced bool
+	}
 
-				// Is TOTP MFA enforced?
-				Enforced bool
+	TOTP struct {
+		// Can users use TOTP MFA?
+		Enabled bool
 
-				// TOTP issuer
-				Issuer string
-			}
-		}
+		// Is TOTP MFA enforced?
+		Enforced bool
+
+		// TOTP issuer
+		Issuer string
 	}
 
 	Provider struct {

--- a/system/types/app_settings_test.go
+++ b/system/types/app_settings_test.go
@@ -1,13 +1,29 @@
 package types
 
 import (
-	sqlTypes "github.com/jmoiron/sqlx/types"
-	"github.com/stretchr/testify/require"
 	"sort"
 	"testing"
+
+	sqlTypes "github.com/jmoiron/sqlx/types"
+	"github.com/stretchr/testify/require"
 )
 
 // 	Hello! This file is auto-generated.
+
+func Test_settingsExtAuthProvidersValidConfiguration(t *testing.T) {
+
+	var (
+		empty        = ExternalAuthProvider{}
+		google       = ExternalAuthProvider{Enabled: true, Handle: "google", Key: "some-guid", Secret: "s3cret"}
+		noIssuerOIDC = ExternalAuthProvider{Enabled: true, Handle: "openid-connect.bar", Key: "some-guid", Secret: "s3cret"}
+		goodOIDC     = ExternalAuthProvider{Enabled: true, Handle: "openid-connect.bar", Key: "some-guid", Secret: "s3cret", IssuerUrl: "https://example.org"}
+	)
+
+	require.False(t, noIssuerOIDC.ValidConfiguration())
+	require.True(t, goodOIDC.ValidConfiguration())
+	require.False(t, empty.ValidConfiguration())
+	require.True(t, google.ValidConfiguration())
+}
 
 func Test_settingsExtAuthProvidersDecode(t *testing.T) {
 	type (


### PR DESCRIPTION
Refactoring and a test fix in app/boot_levels_test.go.

Matches other PR for 2021.3.x branch.