### PR TITLE
Fix sink request processing for workflow handlers

### DIFF
--- a/automation/rest/eventTypes.gen.go
+++ b/automation/rest/eventTypes.gen.go
@@ -2364,13 +2364,13 @@ func getEventTypeDefinitions() []eventTypeDef {
 
 				{
 					Name:      "response",
-					Type:      "",
+					Type:      "SinkResponse",
 					Immutable: false,
 				},
 
 				{
 					Name:      "request",
-					Type:      "",
+					Type:      "SinkRequest",
 					Immutable: true,
 				},
 			},

--- a/pkg/expr/expr_types.gen.go
+++ b/pkg/expr/expr_types.gen.go
@@ -166,6 +166,55 @@ func (t *Boolean) Assign(val interface{}) error {
 	}
 }
 
+// Bytes is an expression type, wrapper for []byte type
+type Bytes struct {
+	value []byte
+	mux   sync.RWMutex
+}
+
+// NewBytes creates new instance of Bytes expression type
+func NewBytes(val interface{}) (*Bytes, error) {
+	if c, err := CastToBytes(val); err != nil {
+		return nil, fmt.Errorf("unable to create Bytes: %w", err)
+	} else {
+		return &Bytes{value: c}, nil
+	}
+}
+
+// Get return underlying value on Bytes
+func (t *Bytes) Get() interface{} {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.value
+}
+
+// GetValue returns underlying value on Bytes
+func (t *Bytes) GetValue() []byte {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.value
+}
+
+// Type return type name
+func (Bytes) Type() string { return "Bytes" }
+
+// Cast converts value to []byte
+func (Bytes) Cast(val interface{}) (TypedValue, error) {
+	return NewBytes(val)
+}
+
+// Assign new value to Bytes
+//
+// value is first passed through CastToBytes
+func (t *Bytes) Assign(val interface{}) error {
+	if c, err := CastToBytes(val); err != nil {
+		return err
+	} else {
+		t.value = c
+		return nil
+	}
+}
+
 // DateTime is an expression type, wrapper for *time.Time type
 type DateTime struct {
 	value *time.Time

--- a/pkg/expr/expr_types.go
+++ b/pkg/expr/expr_types.go
@@ -305,6 +305,23 @@ func CastStringSlice(val interface{}) (out []string, err error) {
 	return cast.ToStringSliceE(UntypedValue(val))
 }
 
+func CastToBytes(val interface{}) (out []byte, err error) {
+	switch v := val.(type) {
+	case io.Reader:
+		buf := bytes.Buffer{}
+		buf.ReadFrom(v)
+		return buf.Bytes(), nil
+	case string:
+		return []byte(v), nil
+	default:
+		aux, err := cast.ToStringE(v)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(aux), nil
+	}
+}
+
 func CastToHandle(val interface{}) (string, error) {
 	val = UntypedValue(val)
 

--- a/pkg/expr/expr_types.yaml
+++ b/pkg/expr/expr_types.yaml
@@ -37,6 +37,10 @@ types:
     as: 'string'
     default: '""'
 
+  Bytes:
+    as: '[]byte'
+    default: 'byte{}'
+
   Handle:
     as: 'string'
     default: '""'

--- a/system/automation/expr_types.gen.go
+++ b/system/automation/expr_types.gen.go
@@ -11,9 +11,10 @@ package automation
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	. "github.com/cortezaproject/corteza-server/pkg/expr"
 	"github.com/cortezaproject/corteza-server/system/types"
-	"sync"
 )
 
 var _ = context.Background
@@ -462,6 +463,414 @@ func assignToRole(res *types.Role, k string, val interface{}) error {
 		return fmt.Errorf("field '%s' is read-only", k)
 	case "deletedAt":
 		return fmt.Errorf("field '%s' is read-only", k)
+	}
+
+	return fmt.Errorf("unknown field '%s'", k)
+}
+
+// SinkRequest is an expression type, wrapper for *types.SinkRequest type
+type SinkRequest struct {
+	value *types.SinkRequest
+	mux   sync.RWMutex
+}
+
+// NewSinkRequest creates new instance of SinkRequest expression type
+func NewSinkRequest(val interface{}) (*SinkRequest, error) {
+	if c, err := CastToSinkRequest(val); err != nil {
+		return nil, fmt.Errorf("unable to create SinkRequest: %w", err)
+	} else {
+		return &SinkRequest{value: c}, nil
+	}
+}
+
+// Get return underlying value on SinkRequest
+func (t *SinkRequest) Get() interface{} {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.value
+}
+
+// GetValue returns underlying value on SinkRequest
+func (t *SinkRequest) GetValue() *types.SinkRequest {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.value
+}
+
+// Type return type name
+func (SinkRequest) Type() string { return "SinkRequest" }
+
+// Cast converts value to *types.SinkRequest
+func (SinkRequest) Cast(val interface{}) (TypedValue, error) {
+	return NewSinkRequest(val)
+}
+
+// Assign new value to SinkRequest
+//
+// value is first passed through CastToSinkRequest
+func (t *SinkRequest) Assign(val interface{}) error {
+	if c, err := CastToSinkRequest(val); err != nil {
+		return err
+	} else {
+		t.value = c
+		return nil
+	}
+}
+
+func (t *SinkRequest) AssignFieldValue(key string, val TypedValue) error {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	return assignToSinkRequest(t.value, key, val)
+}
+
+// SelectGVal implements gval.Selector requirements
+//
+// It allows gval lib to access SinkRequest's underlying value (*types.SinkRequest)
+// and it's fields
+//
+func (t *SinkRequest) SelectGVal(ctx context.Context, k string) (interface{}, error) {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return sinkRequestGValSelector(t.value, k)
+}
+
+// Select is field accessor for *types.SinkRequest
+//
+// Similar to SelectGVal but returns typed values
+func (t *SinkRequest) Select(k string) (TypedValue, error) {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return sinkRequestTypedValueSelector(t.value, k)
+}
+
+func (t *SinkRequest) Has(k string) bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	switch k {
+	case "method":
+		return true
+	case "path":
+		return true
+	case "host":
+		return true
+	case "header":
+		return true
+	case "query":
+		return true
+	case "username":
+		return true
+	case "password":
+		return true
+	case "remoteAddr":
+		return true
+	case "postForm":
+		return true
+	case "body":
+		return true
+	}
+	return false
+}
+
+// sinkRequestGValSelector is field accessor for *types.SinkRequest
+func sinkRequestGValSelector(res *types.SinkRequest, k string) (interface{}, error) {
+	if res == nil {
+		return nil, nil
+	}
+	switch k {
+	case "method":
+		return res.Method, nil
+	case "path":
+		return res.Path, nil
+	case "host":
+		return res.Host, nil
+	case "header":
+		return res.Header, nil
+	case "query":
+		return res.Query, nil
+	case "username":
+		return res.Username, nil
+	case "password":
+		return res.Password, nil
+	case "remoteAddr":
+		return res.RemoteAddr, nil
+	case "postForm":
+		return res.PostForm, nil
+	case "body":
+		return res.Body, nil
+	}
+
+	return nil, fmt.Errorf("unknown field '%s'", k)
+}
+
+// sinkRequestTypedValueSelector is field accessor for *types.SinkRequest
+func sinkRequestTypedValueSelector(res *types.SinkRequest, k string) (TypedValue, error) {
+	if res == nil {
+		return nil, nil
+	}
+	switch k {
+	case "method":
+		return NewString(res.Method)
+	case "path":
+		return NewString(res.Path)
+	case "host":
+		return NewString(res.Host)
+	case "header":
+		return NewKVV(res.Header)
+	case "query":
+		return NewKVV(res.Query)
+	case "username":
+		return NewString(res.Username)
+	case "password":
+		return NewString(res.Password)
+	case "remoteAddr":
+		return NewString(res.RemoteAddr)
+	case "postForm":
+		return NewKVV(res.PostForm)
+	case "body":
+		return NewBytes(res.Body)
+	}
+
+	return nil, fmt.Errorf("unknown field '%s'", k)
+}
+
+// assignToSinkRequest is field value setter for *types.SinkRequest
+func assignToSinkRequest(res *types.SinkRequest, k string, val interface{}) error {
+	switch k {
+	case "method":
+		aux, err := CastToString(val)
+		if err != nil {
+			return err
+		}
+
+		res.Method = aux
+		return nil
+	case "path":
+		aux, err := CastToString(val)
+		if err != nil {
+			return err
+		}
+
+		res.Path = aux
+		return nil
+	case "host":
+		aux, err := CastToString(val)
+		if err != nil {
+			return err
+		}
+
+		res.Host = aux
+		return nil
+	case "header":
+		aux, err := CastToKVV(val)
+		if err != nil {
+			return err
+		}
+
+		res.Header = aux
+		return nil
+	case "query":
+		aux, err := CastToKVV(val)
+		if err != nil {
+			return err
+		}
+
+		res.Query = aux
+		return nil
+	case "username":
+		aux, err := CastToString(val)
+		if err != nil {
+			return err
+		}
+
+		res.Username = aux
+		return nil
+	case "password":
+		aux, err := CastToString(val)
+		if err != nil {
+			return err
+		}
+
+		res.Password = aux
+		return nil
+	case "remoteAddr":
+		aux, err := CastToString(val)
+		if err != nil {
+			return err
+		}
+
+		res.RemoteAddr = aux
+		return nil
+	case "postForm":
+		aux, err := CastToKVV(val)
+		if err != nil {
+			return err
+		}
+
+		res.PostForm = aux
+		return nil
+	case "body":
+		aux, err := CastToBytes(val)
+		if err != nil {
+			return err
+		}
+
+		res.Body = aux
+		return nil
+	}
+
+	return fmt.Errorf("unknown field '%s'", k)
+}
+
+// SinkResponse is an expression type, wrapper for *types.SinkResponse type
+type SinkResponse struct {
+	value *types.SinkResponse
+	mux   sync.RWMutex
+}
+
+// NewSinkResponse creates new instance of SinkResponse expression type
+func NewSinkResponse(val interface{}) (*SinkResponse, error) {
+	if c, err := CastToSinkResponse(val); err != nil {
+		return nil, fmt.Errorf("unable to create SinkResponse: %w", err)
+	} else {
+		return &SinkResponse{value: c}, nil
+	}
+}
+
+// Get return underlying value on SinkResponse
+func (t *SinkResponse) Get() interface{} {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.value
+}
+
+// GetValue returns underlying value on SinkResponse
+func (t *SinkResponse) GetValue() *types.SinkResponse {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.value
+}
+
+// Type return type name
+func (SinkResponse) Type() string { return "SinkResponse" }
+
+// Cast converts value to *types.SinkResponse
+func (SinkResponse) Cast(val interface{}) (TypedValue, error) {
+	return NewSinkResponse(val)
+}
+
+// Assign new value to SinkResponse
+//
+// value is first passed through CastToSinkResponse
+func (t *SinkResponse) Assign(val interface{}) error {
+	if c, err := CastToSinkResponse(val); err != nil {
+		return err
+	} else {
+		t.value = c
+		return nil
+	}
+}
+
+func (t *SinkResponse) AssignFieldValue(key string, val TypedValue) error {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	return assignToSinkResponse(t.value, key, val)
+}
+
+// SelectGVal implements gval.Selector requirements
+//
+// It allows gval lib to access SinkResponse's underlying value (*types.SinkResponse)
+// and it's fields
+//
+func (t *SinkResponse) SelectGVal(ctx context.Context, k string) (interface{}, error) {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return sinkResponseGValSelector(t.value, k)
+}
+
+// Select is field accessor for *types.SinkResponse
+//
+// Similar to SelectGVal but returns typed values
+func (t *SinkResponse) Select(k string) (TypedValue, error) {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return sinkResponseTypedValueSelector(t.value, k)
+}
+
+func (t *SinkResponse) Has(k string) bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	switch k {
+	case "status":
+		return true
+	case "header":
+		return true
+	case "body":
+		return true
+	}
+	return false
+}
+
+// sinkResponseGValSelector is field accessor for *types.SinkResponse
+func sinkResponseGValSelector(res *types.SinkResponse, k string) (interface{}, error) {
+	if res == nil {
+		return nil, nil
+	}
+	switch k {
+	case "status":
+		return res.Status, nil
+	case "header":
+		return res.Header, nil
+	case "body":
+		return res.Body, nil
+	}
+
+	return nil, fmt.Errorf("unknown field '%s'", k)
+}
+
+// sinkResponseTypedValueSelector is field accessor for *types.SinkResponse
+func sinkResponseTypedValueSelector(res *types.SinkResponse, k string) (TypedValue, error) {
+	if res == nil {
+		return nil, nil
+	}
+	switch k {
+	case "status":
+		return NewInteger(res.Status)
+	case "header":
+		return NewKVV(res.Header)
+	case "body":
+		return NewAny(res.Body)
+	}
+
+	return nil, fmt.Errorf("unknown field '%s'", k)
+}
+
+// assignToSinkResponse is field value setter for *types.SinkResponse
+func assignToSinkResponse(res *types.SinkResponse, k string, val interface{}) error {
+	switch k {
+	case "status":
+		aux, err := CastToInteger(val)
+		if err != nil {
+			return err
+		}
+
+		res.Status = int(aux)
+		return nil
+	case "header":
+		aux, err := CastToKVV(val)
+		if err != nil {
+			return err
+		}
+
+		res.Header = aux
+		return nil
+	case "body":
+		aux, err := CastToAny(val)
+		if err != nil {
+			return err
+		}
+
+		res.Body = aux
+		return nil
 	}
 
 	return fmt.Errorf("unknown field '%s'", k)

--- a/system/automation/expr_types.go
+++ b/system/automation/expr_types.go
@@ -141,3 +141,41 @@ func (doc renderedDocument) String() string {
 	aux, _ := ioutil.ReadAll(doc.Document)
 	return string(aux)
 }
+
+func CastToSinkRequest(val interface{}) (out *types.SinkRequest, err error) {
+	switch val := val.(type) {
+	case expr.Iterator:
+		out = &types.SinkRequest{}
+		return out, val.Each(func(k string, v expr.TypedValue) error {
+			return assignToSinkRequest(out, k, v)
+		})
+	}
+
+	switch val := expr.UntypedValue(val).(type) {
+	case *types.SinkRequest:
+		return val, nil
+	case nil:
+		return &types.SinkRequest{}, nil
+	default:
+		return nil, fmt.Errorf("unable to cast type %T to %T", val, out)
+	}
+}
+
+func CastToSinkResponse(val interface{}) (out *types.SinkResponse, err error) {
+	switch val := val.(type) {
+	case expr.Iterator:
+		out = &types.SinkResponse{}
+		return out, val.Each(func(k string, v expr.TypedValue) error {
+			return assignToSinkResponse(out, k, v)
+		})
+	}
+
+	switch val := expr.UntypedValue(val).(type) {
+	case *types.SinkResponse:
+		return val, nil
+	case nil:
+		return &types.SinkResponse{}, nil
+	default:
+		return nil, fmt.Errorf("unable to cast type %T to %T", val, out)
+	}
+}

--- a/system/automation/expr_types.yaml
+++ b/system/automation/expr_types.yaml
@@ -48,6 +48,28 @@ types:
       - { name: 'archivedAt',      exprType: 'DateTime',   goType: '*time.Time', mode: ro }
       - { name: 'deletedAt',       exprType: 'DateTime',   goType: '*time.Time', mode: ro }
 
+  SinkResponse:
+    as: '*types.SinkResponse'
+    struct:
+      - { name: 'status',          exprType: 'Integer',   goType: 'int64'          }
+      - { name: 'header',          exprType: 'KVV',       goType: 'map[string][]string'}
+      - { name: 'body',            exprType: 'Any',       goType: 'interface{}'}
+
+  SinkRequest:
+    as: '*types.SinkRequest'
+    struct:
+      - { name: 'method',         exprType: 'String', goType: 'string'}
+      - { name: 'path',           exprType: 'String', goType: 'string'}
+      - { name: 'host',           exprType: 'String', goType: 'string'}
+      - { name: 'header',         exprType: 'KVV',    goType: 'map[string][]string'}
+      - { name: 'query',          exprType: 'KVV',    goType: 'map[string][]string'}
+      - { name: 'username',       exprType: 'String', goType: 'string'}
+      - { name: 'password',       exprType: 'String', goType: 'string'}
+      - { name: 'remoteAddr',     exprType: 'String', goType: 'string'}
+      - { name: 'postForm',       exprType: 'KVV',    goType: 'map[string][]string'}
+      - { name: 'body',           exprType: 'Bytes',  goType: '[]byte'}
+
+
   DocumentType:
     as: 'types.DocumentType'
   TemplateMeta:

--- a/system/service/event/events.gen.go
+++ b/system/service/event/events.gen.go
@@ -2783,9 +2783,21 @@ func (res sinkBase) EncodeVars() (out *expr.Vars, err error) {
 	out = &expr.Vars{}
 	var v expr.TypedValue
 
-	// Could not found expression-type counterpart for *types.SinkResponse
+	if v, err = automation.NewSinkResponse(res.response); err == nil {
+		err = out.Set("response", v)
+	}
 
-	// Could not found expression-type counterpart for *types.SinkRequest
+	if err != nil {
+		return
+	}
+
+	if v, err = automation.NewSinkRequest(res.request); err == nil {
+		err = out.Set("request", v)
+	}
+
+	if err != nil {
+		return
+	}
 
 	// Could not found expression-type counterpart for auth.Identifiable
 
@@ -2832,7 +2844,15 @@ func (res *sinkBase) DecodeVars(vars *expr.Vars) (err error) {
 		// Respect immutability
 		return
 	}
-	// Could not find expression-type counterpart for *types.SinkResponse
+	if res.response != nil && vars.Has("response") {
+		var aux *automation.SinkResponse
+		aux, err = automation.NewSinkResponse(expr.Must(vars.Select("response")))
+		if err != nil {
+			return
+		}
+
+		res.response = aux.GetValue()
+	}
 	// request marked as immutable
 	// Could not find expression-type counterpart for auth.Identifiable
 

--- a/system/service/sink.go
+++ b/system/service/sink.go
@@ -5,17 +5,19 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/cortezaproject/corteza-server/pkg/actionlog"
-	"github.com/cortezaproject/corteza-server/pkg/api"
-	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
-	"github.com/cortezaproject/corteza-server/pkg/eventbus"
-	"github.com/cortezaproject/corteza-server/system/service/event"
-	"github.com/cortezaproject/corteza-server/system/types"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/actionlog"
+	"github.com/cortezaproject/corteza-server/pkg/api"
+	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/eventbus"
+	"github.com/cortezaproject/corteza-server/pkg/expr"
+	"github.com/cortezaproject/corteza-server/system/service/event"
+	"github.com/cortezaproject/corteza-server/system/types"
 )
 
 type (
@@ -365,11 +367,18 @@ func (svc *sink) process(srup *SinkRequestUrlParams, w http.ResponseWriter, r *h
 
 		w.WriteHeader(rsp.Status)
 
+		var auxb interface{}
+		if cb, ok := rsp.Body.(expr.TypedValue); ok {
+			auxb = cb.Get()
+		} else {
+			auxb = rsp.Body
+		}
+
 		var output []byte
-		if bb, ok := rsp.Body.([]byte); ok {
+		if bb, ok := auxb.([]byte); ok {
 			// Ok, handled
 			output = bb
-		} else if s, ok := rsp.Body.(string); ok {
+		} else if s, ok := auxb.(string); ok {
 			output = []byte(s)
 		}
 


### PR DESCRIPTION
What is done:

* added missing automation type definitions
* added support for `TypedValue` -> HTTP reponse encoding

Questions:

* should we support a wider range of types when encoding the HTTP response? Currently we just do strings and bytes. We can probably also do maps and such?
* there is a manual tweak in one of the generated files (a cast to `int` from `int64`). I am not sure how we should handle that one.