### PR TITLE
Fix flaky workflow stack trace logging

### DIFF
--- a/automation/types/session.go
+++ b/automation/types/session.go
@@ -105,15 +105,15 @@ func NewSession(s *wfexec.Session) *Session {
 	}
 }
 
-func (s Session) Exec(ctx context.Context, step wfexec.Step, input *expr.Vars) error {
+func (s *Session) Exec(ctx context.Context, step wfexec.Step, input *expr.Vars) error {
 	return s.session.Exec(ctx, step, input)
 }
 
-func (s Session) Resume(ctx context.Context, stateID uint64, input *expr.Vars) error {
+func (s *Session) Resume(ctx context.Context, stateID uint64, input *expr.Vars) error {
 	return s.session.Resume(ctx, stateID, input)
 }
 
-func (s Session) PendingPrompts(ownerId uint64) []*wfexec.PendingPrompt {
+func (s *Session) PendingPrompts(ownerId uint64) []*wfexec.PendingPrompt {
 	return s.session.PendingPrompts(ownerId)
 }
 

--- a/tests/workflows/0010_stacktrace_test.go
+++ b/tests/workflows/0010_stacktrace_test.go
@@ -1,0 +1,55 @@
+package workflows
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	autTypes "github.com/cortezaproject/corteza-server/automation/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test0010_stacktrace(t *testing.T) {
+	var (
+		ctx = superUser(context.Background())
+		req = require.New(t)
+	)
+
+	req.NoError(defStore.TruncateComposeRecords(ctx, nil))
+	req.NoError(defStore.TruncateComposeModules(ctx))
+	req.NoError(defStore.TruncateComposeNamespaces(ctx))
+
+	loadScenario(ctx, t)
+
+	for rep := 0; rep < 10; rep++ {
+		t.Run(fmt.Sprintf("iteration %d", rep), func(t *testing.T) {
+			var (
+				_, trace = mustExecWorkflow(ctx, t, "testing", autTypes.WorkflowExecParams{})
+			)
+
+			// 6x iterator, 5x continue, 1x terminator, 1x completed
+			req.Len(trace, 13)
+
+			steps := []uint64{
+				10,
+				11,
+				10,
+				11,
+				10,
+				11,
+				10,
+				11,
+				10,
+				11,
+
+				10,
+				12,
+				0,
+			}
+
+			for i := 0; i < 13; i++ {
+				req.Equal(steps[i], trace[i].StepID)
+			}
+		})
+	}
+}

--- a/tests/workflows/0011_termination_explicit_test.go
+++ b/tests/workflows/0011_termination_explicit_test.go
@@ -1,0 +1,27 @@
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	autTypes "github.com/cortezaproject/corteza-server/automation/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test0011_termination_explicit(t *testing.T) {
+	var (
+		ctx = superUser(context.Background())
+		req = require.New(t)
+	)
+
+	loadScenario(ctx, t)
+
+	var (
+		_, trace = mustExecWorkflow(ctx, t, "testing", autTypes.WorkflowExecParams{})
+	)
+
+	req.Len(trace, 3)
+	req.Equal(uint64(10), trace[0].StepID)
+	req.Equal(uint64(11), trace[1].StepID)
+	req.Equal(uint64(0), trace[2].StepID)
+}

--- a/tests/workflows/0012_termination_implicit_test.go
+++ b/tests/workflows/0012_termination_implicit_test.go
@@ -1,0 +1,26 @@
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	autTypes "github.com/cortezaproject/corteza-server/automation/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test0012_termination_implicit(t *testing.T) {
+	var (
+		ctx = superUser(context.Background())
+		req = require.New(t)
+	)
+
+	loadScenario(ctx, t)
+
+	var (
+		_, trace = mustExecWorkflow(ctx, t, "testing", autTypes.WorkflowExecParams{})
+	)
+
+	req.Len(trace, 2)
+	req.Equal(uint64(10), trace[0].StepID)
+	req.Equal(uint64(0), trace[1].StepID)
+}

--- a/tests/workflows/testdata/S0010_stacktrace/data_model.yaml
+++ b/tests/workflows/testdata/S0010_stacktrace/data_model.yaml
@@ -1,0 +1,25 @@
+namespaces:
+  ns1:
+    name: ns1 name
+
+modules:
+  mod1:
+    name: mod1 name
+    fields:
+      f1:
+        label: f1 label
+        kind: String
+        required: false
+
+records:
+  mod1:
+    - values:
+        f1: 1
+    - values:
+        f1: 2
+    - values:
+        f1: 3
+    - values:
+        f1: 4
+    - values:
+        f1: 5

--- a/tests/workflows/testdata/S0010_stacktrace/workflow.yaml
+++ b/tests/workflows/testdata/S0010_stacktrace/workflow.yaml
@@ -1,0 +1,29 @@
+workflows:
+  testing:
+    enabled: true
+    trace: true
+    triggers:
+      - enabled: true
+        stepID: 10
+
+    steps:
+      - stepID: 10
+        kind: iterator
+        ref: composeRecordsEach
+        arguments:
+          - { "target": "module", "value": "mod1", "type": "Handle" }
+          - { "target": "namespace", "value": "ns1", "type": "Handle" }
+        results:
+          - { "target": "r", "expr": "record" }
+          - { "target": "i", "expr": "index" }
+          - { "target": "t", "expr": "total" }
+
+      - stepID: 11
+        kind: continue
+
+      - stepID: 12
+        kind: termination
+
+    paths:
+      - { parentID: 10, childID: 11 }
+      - { parentID: 10, childID: 12 }

--- a/tests/workflows/testdata/S0011_termination_explicit/workflow.yaml
+++ b/tests/workflows/testdata/S0011_termination_explicit/workflow.yaml
@@ -1,0 +1,19 @@
+workflows:
+  testing:
+    enabled: true
+    trace: true
+    triggers:
+      - enabled: true
+        stepID: 10
+
+    steps:
+      - stepID: 10
+        kind: expressions
+        arguments:
+          - { "target": "test", "value": "42", "type": "Any" }
+
+      - stepID: 11
+        kind: termination
+
+    paths:
+      - { parentID: 10, childID: 11 }

--- a/tests/workflows/testdata/S0012_termination_implicit/workflow.yaml
+++ b/tests/workflows/testdata/S0012_termination_implicit/workflow.yaml
@@ -1,0 +1,13 @@
+workflows:
+  testing:
+    enabled: true
+    trace: true
+    triggers:
+      - enabled: true
+        stepID: 10
+
+    steps:
+      - stepID: 10
+        kind: expressions
+        arguments:
+          - { "target": "test", "value": "42", "type": "Any" }


### PR DESCRIPTION
Prevent worker routines from queueing next steps to help assure
correct stack traces.

(( forward to .9 as well ))

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
