### PR TITLE
Updates expr function `count` to return count based on params

### DIFF
--- a/pkg/expr/func_arr.go
+++ b/pkg/expr/func_arr.go
@@ -2,9 +2,9 @@ package expr
 
 import (
 	"fmt"
-	"reflect"
-
 	"github.com/PaesslerAG/gval"
+	"reflect"
+	"strings"
 )
 
 func ArrayFunctions() []gval.Language {
@@ -94,15 +94,29 @@ func shift(arr interface{}) (out interface{}, err error) {
 	return c.Index(0).Interface(), nil
 }
 
-// count gets the count of occurrences in the slice
+// count gets the count of occurrences in the first params(can be string, slice)
+// If given only one parameter then it returns length as count
 func count(arr interface{}, v ...interface{}) (count int, err error) {
+	var (
+		occ int
+		c   = reflect.ValueOf(arr)
+	)
+
+	if len(v) == 0 {
+		return c.Len(), nil
+	}
+
+	if c.Kind() == reflect.String {
+		for _, ww := range v {
+			count += strings.Count(c.String(), reflect.ValueOf(ww).String())
+		}
+		return
+	}
+
 	if arr, err = toSlice(arr); err != nil {
 		return
 	}
 
-	var (
-		occ int
-	)
 	for _, vv := range v {
 		if occ, err = find(arr, vv); err != nil {
 			return 0, err

--- a/pkg/expr/func_arr_test.go
+++ b/pkg/expr/func_arr_test.go
@@ -264,6 +264,36 @@ func Test_count(t *testing.T) {
 			val:    []interface{}{0.1, 1.1},
 			expect: 0,
 		},
+		{
+			arr:    "foo",
+			val:    nil,
+			expect: 3,
+		},
+		{
+			arr:    "foo",
+			val:    []interface{}{},
+			expect: 3,
+		},
+		{
+			arr:    "foo bar",
+			val:    []interface{}{},
+			expect: 7,
+		},
+		{
+			arr:    []bool{true, true},
+			val:    []interface{}{},
+			expect: 2,
+		},
+		{
+			arr:    "foo",
+			val:    []interface{}{"bar", "baz"},
+			expect: 0,
+		},
+		{
+			arr:    "foo",
+			val:    []interface{}{"o", 12},
+			expect: 2,
+		},
 	}
 
 	for p, tc := range tcc {


### PR DESCRIPTION
- count(foo) counts all elements
- count(foo, 'bar', 'baz') counts number of bars and bazs in foo

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
