### PR TITLE
2021.3.x feature invoker runner

### DIFF
--- a/automation/service/service.go
+++ b/automation/service/service.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cortezaproject/corteza-server/pkg/options"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	"github.com/cortezaproject/corteza-server/store"
-	"github.com/cortezaproject/corteza-server/system/types"
+	sysTypes "github.com/cortezaproject/corteza-server/system/types"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +30,7 @@ type (
 	}
 
 	userService interface {
-		FindByAny(ctx context.Context, identifier interface{}) (*types.User, error)
+		FindByAny(ctx context.Context, identifier interface{}) (*sysTypes.User, error)
 	}
 )
 

--- a/automation/service/trigger.go
+++ b/automation/service/trigger.go
@@ -605,12 +605,24 @@ func (svc *trigger) unregisterTriggers(tt ...*types.Trigger) {
 	}
 }
 
-func loadTrigger(ctx context.Context, s store.Storer, workflowID uint64) (res *types.Trigger, err error) {
+func loadTrigger(ctx context.Context, s store.Storer, triggerID uint64) (res *types.Trigger, err error) {
+	if triggerID == 0 {
+		return nil, TriggerErrInvalidID()
+	}
+
+	if res, err = store.LookupAutomationTriggerByID(ctx, s, triggerID); errors.IsNotFound(err) {
+		return nil, TriggerErrNotFound()
+	}
+
+	return
+}
+
+func loadWorkflowTriggers(ctx context.Context, s store.Storer, workflowID uint64) (tt types.TriggerSet, err error) {
 	if workflowID == 0 {
 		return nil, TriggerErrInvalidID()
 	}
 
-	if res, err = store.LookupAutomationTriggerByID(ctx, s, workflowID); errors.IsNotFound(err) {
+	if tt, _, err = store.SearchAutomationTriggers(ctx, s, types.TriggerFilter{WorkflowID: []uint64{workflowID}}); errors.IsNotFound(err) {
 		return nil, TriggerErrNotFound()
 	}
 

--- a/automation/service/workflow.go
+++ b/automation/service/workflow.go
@@ -525,7 +525,9 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 		// Find the trigger.
 		t, err = func() (*types.Trigger, error) {
 			var tt types.TriggerSet
-			tt, _, err = svc.triggers.Search(ctx, types.TriggerFilter{WorkflowID: []uint64{workflowID}})
+			// Load triggers directly from the store. At this point we do not care
+			// about trigger search or read permissions
+			tt, err = loadWorkflowTriggers(ctx, svc.store, workflowID)
 			if err != nil {
 				return nil, err
 			}
@@ -542,6 +544,10 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 
 			return nil, nil
 		}()
+
+		if err != nil {
+			return
+		}
 
 		// Start with workflow scope
 		scope := wf.Scope.Merge()

--- a/tests/workflows/invoker_and_runner_in_scope_test.go
+++ b/tests/workflows/invoker_and_runner_in_scope_test.go
@@ -1,0 +1,84 @@
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cortezaproject/corteza-server/automation/types"
+	"github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/rbac"
+	sysTypes "github.com/cortezaproject/corteza-server/system/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_invoker_and_runner_in_scope(t *testing.T) {
+	var (
+		ctx = superUser(context.Background())
+		req = require.New(t)
+	)
+
+	req.NoError(defStore.TruncateUsers(ctx))
+	req.NoError(defStore.TruncateRoles(ctx))
+	req.NoError(defStore.TruncateRoleMembers(ctx))
+	req.NoError(defStore.TruncateRbacRules(ctx))
+
+	loadNewScenario(ctx, t)
+
+	// user that the workflow is configured to use for run-as
+	wfRunner, err := defStore.LookupUserByHandle(ctx, "wf-runner")
+	req.NoError(err)
+
+	// user invoking the workflow
+	wfInvoker, err := defStore.LookupUserByHandle(ctx, "wf-invoker")
+	req.NoError(err)
+
+	// invokers group with permissions to execute workflow
+	wfInvokers, err := defStore.LookupRoleByHandle(ctx, "wf-invokers")
+	req.NoError(err)
+	err = defStore.CreateRoleMember(ctx, &sysTypes.RoleMember{UserID: wfInvoker.ID, RoleID: wfInvokers.ID})
+	req.NoError(err)
+
+	wfInvoker.SetRoles([]uint64{wfInvokers.ID})
+	ctx = auth.SetIdentityToContext(ctx, wfInvoker)
+
+	rbac.Global().Reload(ctx)
+
+	t.Run("invoker set in scope", func(t *testing.T) {
+		var (
+			req = require.New(t)
+			aux = struct {
+				Invoker *sysTypes.User
+				Runner  *sysTypes.User
+			}{}
+		)
+
+		vars, _ := mustExecWorkflow(ctx, t, "invoker", types.WorkflowExecParams{})
+		req.NoError(vars.Decode(&aux))
+
+		// Expecting both, invoker & runner to be same as invoker
+		req.NotNil(aux.Runner)
+		req.NotNil(aux.Invoker)
+		req.Equal(aux.Runner.Handle, wfInvoker.Handle)
+		req.Equal(aux.Invoker.Handle, wfInvoker.Handle)
+	})
+
+	t.Run("runner set in scope", func(t *testing.T) {
+		var (
+			req = require.New(t)
+			aux = struct {
+				Invoker *sysTypes.User
+				Runner  *sysTypes.User
+			}{}
+		)
+
+		vars, _ := mustExecWorkflow(ctx, t, "runner", types.WorkflowExecParams{})
+		req.NoError(vars.Decode(&aux))
+
+		// Expecting runner and invoker to be different.
+		req.NotNil(aux.Runner)
+		req.NotNil(aux.Invoker)
+		req.Equal(aux.Runner.Handle, wfRunner.Handle)
+		req.Equal(aux.Invoker.Handle, wfInvoker.Handle)
+	})
+
+}

--- a/tests/workflows/main_test.go
+++ b/tests/workflows/main_test.go
@@ -66,6 +66,13 @@ func loadScenario(ctx context.Context, t *testing.T) {
 	loadScenarioWithName(ctx, t, "S"+t.Name()[4:])
 }
 
+// 1st step in migration to workflow testdata w/o number prefix
+//
+// When all old scenarios are renamed, replace it with loadScenario.
+func loadNewScenario(ctx context.Context, t *testing.T) {
+	loadScenarioWithName(ctx, t, t.Name()[5:])
+}
+
 func loadScenarioWithName(ctx context.Context, t *testing.T, scenario string) {
 	var (
 		err error
@@ -130,7 +137,11 @@ func mustExecWorkflow(ctx context.Context, t *testing.T, name string, p autTypes
 			}
 		}
 
-		t.Fatalf("could not exec %q: %v", name, errors.Unwrap(err))
+		if unw := errors.Unwrap(err); unw != nil {
+			err = unw
+		}
+
+		t.Fatalf("could not exec %q: %v", name, err)
 
 	}
 

--- a/tests/workflows/testdata/invoker_and_runner_in_scope/users.yaml
+++ b/tests/workflows/testdata/invoker_and_runner_in_scope/users.yaml
@@ -1,0 +1,8 @@
+users:
+  wf-runner: workflow-runner@cortezaproject.org
+  wf-invoker: workflow-invoker@cortezaproject.org
+
+roles:
+  wf-invokers:
+    members:
+      - wf-invoker

--- a/tests/workflows/testdata/invoker_and_runner_in_scope/workflow.yaml
+++ b/tests/workflows/testdata/invoker_and_runner_in_scope/workflow.yaml
@@ -1,0 +1,33 @@
+workflows:
+  invoker:
+    enabled: true
+    trace: true
+    triggers:
+      - enabled: true
+        stepID: 1
+
+    steps:
+      - stepID: 1
+        kind: termination
+
+    paths: []
+    allow:
+      wf-invokers:
+        - execute
+
+  runner:
+    enabled: true
+    trace: true
+    runAs: wf-runner
+    triggers:
+      - enabled: true
+        stepID: 1
+
+    steps:
+      - stepID: 1
+        kind: termination
+
+    paths: []
+    allow:
+      wf-invokers:
+        - execute


### PR DESCRIPTION
When workflow loads we need to set one or two new variables to scope (both of type `system.User`):

`invoker` for the user that triggered the workflow. For events that are not triggered by a user (on interval, on timestamp, on request) but as consequence of some scheduled or external event this value is NOT set.

`runner` for user that executed the workflow. If runAs is configured on the workflow it points to the run-as user. Otherwise it is the same as `invoker`

This will also be applied to 2021.9.x.

