### PR TITLE
Excludes deleted reminders from reminderList API

### DIFF
--- a/store/rdbms/reminder.go
+++ b/store/rdbms/reminder.go
@@ -17,6 +17,10 @@ func (s Store) convertReminderFilter(f types.ReminderFilter) (query squirrel.Sel
 		query = query.Where("rmd.dismissed_at IS NULL")
 	}
 
+	if !f.IncludeDeleted {
+		query = query.Where("rmd.deleted_at IS NULL")
+	}
+
 	if f.ScheduledOnly {
 		query = query.Where("rmd.remind_at IS NOT NULL")
 	}

--- a/system/rest.yaml
+++ b/system/rest.yaml
@@ -987,6 +987,10 @@ endpoints:
         required: false
         title: Filter out dismissed reminders
         type: bool
+      - name: includeDeleted
+        required: false
+        title: Includes deleted reminders
+        type: bool
       - type: uint
         name: limit
         title: Limit

--- a/system/rest/reminder.go
+++ b/system/rest/reminder.go
@@ -40,6 +40,7 @@ func (ctrl *Reminder) List(ctx context.Context, r *request.ReminderList) (interf
 			ScheduledFrom:    r.ScheduledFrom,
 			ScheduledUntil:   r.ScheduledUntil,
 			ExcludeDismissed: r.ExcludeDismissed,
+			IncludeDeleted:   r.IncludeDeleted,
 			ScheduledOnly:    r.ScheduledOnly,
 		}
 	)
@@ -52,8 +53,8 @@ func (ctrl *Reminder) List(ctx context.Context, r *request.ReminderList) (interf
 		return nil, err
 	}
 
-	set, filter, err := ctrl.reminder.Find(ctx, f)
-	return ctrl.makeFilterPayload(ctx, set, filter, err)
+	set, f, err := ctrl.reminder.Find(ctx, f)
+	return ctrl.makeFilterPayload(ctx, set, f, err)
 }
 
 func (ctrl *Reminder) Create(ctx context.Context, r *request.ReminderCreate) (interface{}, error) {

--- a/system/rest/request/reminder.go
+++ b/system/rest/request/reminder.go
@@ -71,6 +71,11 @@ type (
 		// Filter out dismissed reminders
 		ExcludeDismissed bool
 
+		// IncludeDeleted GET parameter
+		//
+		// Includes deleted reminders
+		IncludeDeleted bool
+
 		// Limit GET parameter
 		//
 		// Limit
@@ -185,6 +190,7 @@ func (r ReminderList) Auditable() map[string]interface{} {
 		"scheduledUntil":   r.ScheduledUntil,
 		"scheduledOnly":    r.ScheduledOnly,
 		"excludeDismissed": r.ExcludeDismissed,
+		"includeDeleted":   r.IncludeDeleted,
 		"limit":            r.Limit,
 		"pageCursor":       r.PageCursor,
 		"sort":             r.Sort,
@@ -224,6 +230,11 @@ func (r ReminderList) GetScheduledOnly() bool {
 // Auditable returns all auditable/loggable parameters
 func (r ReminderList) GetExcludeDismissed() bool {
 	return r.ExcludeDismissed
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ReminderList) GetIncludeDeleted() bool {
+	return r.IncludeDeleted
 }
 
 // Auditable returns all auditable/loggable parameters
@@ -291,6 +302,12 @@ func (r *ReminderList) Fill(req *http.Request) (err error) {
 		}
 		if val, ok := tmp["excludeDismissed"]; ok && len(val) > 0 {
 			r.ExcludeDismissed, err = payload.ParseBool(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["includeDeleted"]; ok && len(val) > 0 {
+			r.IncludeDeleted, err = payload.ParseBool(val[0]), nil
 			if err != nil {
 				return err
 			}

--- a/system/types/reminder.go
+++ b/system/types/reminder.go
@@ -35,6 +35,7 @@ type (
 		ScheduledFrom    *time.Time `json:"scheduledFrom"`
 		ScheduledUntil   *time.Time `json:"scheduledUntil"`
 		ExcludeDismissed bool       `json:"excludeDismissed"`
+		IncludeDeleted   bool       `json:"includeDeleted"`
 		ScheduledOnly    bool       `json:"scheduledOnly"`
 
 		// Check fn is called by store backend for each resource found function can


### PR DESCRIPTION
- Adds `includeDeleted` filter to include deleted reminders in reminderList API

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
