### PR TITLE
Fix create and update with unique constraints

### DIFF
--- a/store/rdbms/actionlog.gen.go
+++ b/store/rdbms/actionlog.gen.go
@@ -220,5 +220,13 @@ func (s *Store) checkActionlogConstraints(ctx context.Context, res *actionlog.Ac
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/apigw_filter.gen.go
+++ b/store/rdbms/apigw_filter.gen.go
@@ -567,5 +567,13 @@ func (s *Store) checkApigwFilterConstraints(ctx context.Context, res *types.Apig
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/apigw_route.gen.go
+++ b/store/rdbms/apigw_route.gen.go
@@ -564,5 +564,13 @@ func (s *Store) checkApigwRouteConstraints(ctx context.Context, res *types.Apigw
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/applications.gen.go
+++ b/store/rdbms/applications.gen.go
@@ -602,5 +602,13 @@ func (s *Store) checkApplicationConstraints(ctx context.Context, res *types.Appl
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/attachments.gen.go
+++ b/store/rdbms/attachments.gen.go
@@ -351,5 +351,13 @@ func (s *Store) checkAttachmentConstraints(ctx context.Context, res *types.Attac
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/automation_sessions.gen.go
+++ b/store/rdbms/automation_sessions.gen.go
@@ -624,5 +624,13 @@ func (s *Store) checkAutomationSessionConstraints(ctx context.Context, res *type
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/automation_triggers.gen.go
+++ b/store/rdbms/automation_triggers.gen.go
@@ -604,5 +604,13 @@ func (s *Store) checkAutomationTriggerConstraints(ctx context.Context, res *type
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/automation_workflows.gen.go
+++ b/store/rdbms/automation_workflows.gen.go
@@ -643,11 +643,26 @@ func (s *Store) checkAutomationWorkflowConstraints(ctx context.Context, res *typ
 		return nil
 	}
 
-	{
+	var checks = make([]func() error, 0)
+
+	checks = append(checks, func() error {
+		// Skip lookup by Handle if AutomationWorkflow does not match filters
+		if res.DeletedAt != nil {
+			return nil
+		}
+
 		ex, err := s.LookupAutomationWorkflowByHandle(ctx, res.Handle)
 		if err == nil && ex != nil && ex.ID != res.ID {
 			return store.ErrNotUnique.Stack(1)
 		} else if !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	for _, check := range checks {
+		if err := check(); err != nil {
 			return err
 		}
 	}

--- a/store/rdbms/compose_attachments.gen.go
+++ b/store/rdbms/compose_attachments.gen.go
@@ -354,5 +354,13 @@ func (s *Store) checkComposeAttachmentConstraints(ctx context.Context, res *type
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/compose_charts.gen.go
+++ b/store/rdbms/compose_charts.gen.go
@@ -610,5 +610,13 @@ func (s *Store) checkComposeChartConstraints(ctx context.Context, res *types.Cha
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/compose_module_fields.gen.go
+++ b/store/rdbms/compose_module_fields.gen.go
@@ -364,11 +364,26 @@ func (s *Store) checkComposeModuleFieldConstraints(ctx context.Context, res *typ
 		return nil
 	}
 
-	{
+	var checks = make([]func() error, 0)
+
+	checks = append(checks, func() error {
+		// Skip lookup by ModuleIDName if ComposeModuleField does not match filters
+		if res.DeletedAt != nil {
+			return nil
+		}
+
 		ex, err := s.LookupComposeModuleFieldByModuleIDName(ctx, res.ModuleID, res.Name)
 		if err == nil && ex != nil && ex.ID != res.ID {
 			return store.ErrNotUnique.Stack(1)
 		} else if !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	for _, check := range checks {
+		if err := check(); err != nil {
 			return err
 		}
 	}

--- a/store/rdbms/compose_modules.gen.go
+++ b/store/rdbms/compose_modules.gen.go
@@ -624,11 +624,26 @@ func (s *Store) checkComposeModuleConstraints(ctx context.Context, res *types.Mo
 		return nil
 	}
 
-	{
+	var checks = make([]func() error, 0)
+
+	checks = append(checks, func() error {
+		// Skip lookup by NamespaceIDHandle if ComposeModule does not match filters
+		if res.DeletedAt != nil {
+			return nil
+		}
+
 		ex, err := s.LookupComposeModuleByNamespaceIDHandle(ctx, res.NamespaceID, res.Handle)
 		if err == nil && ex != nil && ex.ID != res.ID {
 			return store.ErrNotUnique.Stack(1)
 		} else if !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	for _, check := range checks {
+		if err := check(); err != nil {
 			return err
 		}
 	}

--- a/store/rdbms/compose_namespaces.gen.go
+++ b/store/rdbms/compose_namespaces.gen.go
@@ -611,11 +611,26 @@ func (s *Store) checkComposeNamespaceConstraints(ctx context.Context, res *types
 		return nil
 	}
 
-	{
+	var checks = make([]func() error, 0)
+
+	checks = append(checks, func() error {
+		// Skip lookup by Slug if ComposeNamespace does not match filters
+		if res.DeletedAt != nil {
+			return nil
+		}
+
 		ex, err := s.LookupComposeNamespaceBySlug(ctx, res.Slug)
 		if err == nil && ex != nil && ex.ID != res.ID {
 			return store.ErrNotUnique.Stack(1)
 		} else if !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	for _, check := range checks {
+		if err := check(); err != nil {
 			return err
 		}
 	}

--- a/store/rdbms/compose_pages.gen.go
+++ b/store/rdbms/compose_pages.gen.go
@@ -631,5 +631,13 @@ func (s *Store) checkComposePageConstraints(ctx context.Context, res *types.Page
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/compose_record_values.gen.go
+++ b/store/rdbms/compose_record_values.gen.go
@@ -324,5 +324,13 @@ func (s *Store) checkComposeRecordValueConstraints(ctx context.Context, _mod *ty
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/compose_records.gen.go
+++ b/store/rdbms/compose_records.gen.go
@@ -489,5 +489,13 @@ func (s *Store) checkComposeRecordConstraints(ctx context.Context, _mod *types.M
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/credentials.gen.go
+++ b/store/rdbms/credentials.gen.go
@@ -344,5 +344,13 @@ func (s *Store) checkCredentialsConstraints(ctx context.Context, res *types.Cred
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/federation_exposed_modules.gen.go
+++ b/store/rdbms/federation_exposed_modules.gen.go
@@ -595,5 +595,13 @@ func (s *Store) checkFederationExposedModuleConstraints(ctx context.Context, res
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/federation_module_mappings.gen.go
+++ b/store/rdbms/federation_module_mappings.gen.go
@@ -612,5 +612,13 @@ func (s *Store) checkFederationModuleMappingConstraints(ctx context.Context, res
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/federation_nodes.gen.go
+++ b/store/rdbms/federation_nodes.gen.go
@@ -378,5 +378,13 @@ func (s *Store) checkFederationNodeConstraints(ctx context.Context, res *types.N
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/federation_nodes_sync.gen.go
+++ b/store/rdbms/federation_nodes_sync.gen.go
@@ -588,5 +588,13 @@ func (s *Store) checkFederationNodesSyncConstraints(ctx context.Context, res *ty
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/federation_shared_modules.gen.go
+++ b/store/rdbms/federation_shared_modules.gen.go
@@ -592,5 +592,13 @@ func (s *Store) checkFederationSharedModuleConstraints(ctx context.Context, res 
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/messagebus_queue_message.gen.go
+++ b/store/rdbms/messagebus_queue_message.gen.go
@@ -519,5 +519,13 @@ func (s *Store) checkMessagebusQueueMessageConstraints(ctx context.Context, res 
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/messagebus_queue_settings.gen.go
+++ b/store/rdbms/messagebus_queue_settings.gen.go
@@ -578,5 +578,13 @@ func (s *Store) checkMessagebusQueueSettingConstraints(ctx context.Context, res 
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/rbac_rules.gen.go
+++ b/store/rdbms/rbac_rules.gen.go
@@ -315,5 +315,13 @@ func (s *Store) checkRbacRuleConstraints(ctx context.Context, res *rbac.Rule) er
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/reminders.gen.go
+++ b/store/rdbms/reminders.gen.go
@@ -613,5 +613,13 @@ func (s *Store) checkReminderConstraints(ctx context.Context, res *types.Reminde
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/reports.gen.go
+++ b/store/rdbms/reports.gen.go
@@ -621,11 +621,26 @@ func (s *Store) checkReportConstraints(ctx context.Context, res *types.Report) e
 		return nil
 	}
 
-	{
+	var checks = make([]func() error, 0)
+
+	checks = append(checks, func() error {
+		// Skip lookup by Handle if Report does not match filters
+		if res.DeletedAt != nil {
+			return nil
+		}
+
 		ex, err := s.LookupReportByHandle(ctx, res.Handle)
 		if err == nil && ex != nil && ex.ID != res.ID {
 			return store.ErrNotUnique.Stack(1)
 		} else if !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	for _, check := range checks {
+		if err := check(); err != nil {
 			return err
 		}
 	}

--- a/store/rdbms/resource_translation.gen.go
+++ b/store/rdbms/resource_translation.gen.go
@@ -614,5 +614,13 @@ func (s *Store) checkResourceTranslationConstraints(ctx context.Context, res *ty
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/role_members.gen.go
+++ b/store/rdbms/role_members.gen.go
@@ -310,5 +310,13 @@ func (s *Store) checkRoleMemberConstraints(ctx context.Context, res *types.RoleM
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/settings.gen.go
+++ b/store/rdbms/settings.gen.go
@@ -337,5 +337,13 @@ func (s *Store) checkSettingConstraints(ctx context.Context, res *types.SettingV
 		return nil
 	}
 
+	var checks = make([]func() error, 0)
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/store/rdbms/templates.gen.go
+++ b/store/rdbms/templates.gen.go
@@ -627,11 +627,26 @@ func (s *Store) checkTemplateConstraints(ctx context.Context, res *types.Templat
 		return nil
 	}
 
-	{
+	var checks = make([]func() error, 0)
+
+	checks = append(checks, func() error {
+		// Skip lookup by Handle if Template does not match filters
+		if res.DeletedAt != nil {
+			return nil
+		}
+
 		ex, err := s.LookupTemplateByHandle(ctx, res.Handle)
 		if err == nil && ex != nil && ex.ID != res.ID {
 			return store.ErrNotUnique.Stack(1)
 		} else if !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	for _, check := range checks {
+		if err := check(); err != nil {
 			return err
 		}
 	}

--- a/store/tests/roles_test.go
+++ b/store/tests/roles_test.go
@@ -2,6 +2,10 @@ package tests
 
 import (
 	"context"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/id"
 	"github.com/cortezaproject/corteza-server/pkg/rand"
@@ -9,9 +13,6 @@ import (
 	"github.com/cortezaproject/corteza-server/system/types"
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
-	"time"
 )
 
 func testRoles(t *testing.T, s store.Roles) {
@@ -71,6 +72,15 @@ func testRoles(t *testing.T, s store.Roles) {
 	t.Run("update", func(t *testing.T) {
 		req, role := truncAndCreate(t)
 		req.NoError(s.UpdateRole(ctx, role))
+	})
+
+	t.Run("create and update deleted with existing handle", func(t *testing.T) {
+		req, role := truncAndCreate(t)
+		deletedRole := makeNew("copy")
+		deletedRole.DeletedAt = now()
+		deletedRole.Handle = role.Handle
+		req.NoError(store.CreateRole(ctx, s, deletedRole))
+		req.NoError(store.UpdateRole(ctx, s, deletedRole))
 	})
 
 	t.Run("lookup by handle", func(t *testing.T) {

--- a/store/tests/users_test.go
+++ b/store/tests/users_test.go
@@ -3,6 +3,10 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/id"
 	"github.com/cortezaproject/corteza-server/pkg/rand"
@@ -10,9 +14,6 @@ import (
 	"github.com/cortezaproject/corteza-server/system/types"
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
-	"time"
 )
 
 func testUsers(t *testing.T, s store.Users) {
@@ -142,6 +143,15 @@ func testUsers(t *testing.T, s store.Users) {
 		fetched, err := store.LookupUserByUsername(ctx, s, user.Username)
 		req.NoError(err)
 		req.Equal(user.ID, fetched.ID)
+	})
+
+	t.Run("create and update deleted with existing email", func(t *testing.T) {
+		req, user := truncAndCreate(t)
+		deletedUser := makeNew("copy")
+		deletedUser.DeletedAt = now()
+		deletedUser.Email = user.Email
+		req.NoError(store.CreateUser(ctx, s, deletedUser))
+		req.NoError(store.UpdateUser(ctx, s, deletedUser))
 	})
 
 	t.Run("search", func(t *testing.T) {


### PR DESCRIPTION
When creating or updating resource that did not match unique constraint
filters, check wrongly reported not-unique error when matching (and
valid) resource was found in the store.

This fix adds explicit check if resource to be stored does not match
constraint filters and skips the rest of the constraint checking
procedure.
