### PR TITLE
Refactor role security, support it for ext. auth flow

### DIFF
--- a/auth/oauth2/user_authorizer.go
+++ b/auth/oauth2/user_authorizer.go
@@ -2,9 +2,12 @@ package oauth2
 
 import (
 	"fmt"
-	"github.com/cortezaproject/corteza-server/auth/request"
-	"github.com/go-oauth2/oauth2/v4/server"
 	"net/http"
+
+	"github.com/cortezaproject/corteza-server/auth/request"
+	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/payload"
+	"github.com/go-oauth2/oauth2/v4/server"
 )
 
 func NewUserAuthorizer(sm *request.SessionManager, loginURL, clientAuthURL string) server.UserAuthorizationHandler {
@@ -40,7 +43,12 @@ func NewUserAuthorizer(sm *request.SessionManager, loginURL, clientAuthURL strin
 		var roles = request.GetRoleMemberships(ses)
 		if client.Security != nil {
 			// filter user's roles with client security settings
-			roles = client.Security.ProcessRoles(roles...)
+			roles = internalAuth.ApplyRoleSecurity(
+				payload.ParseUint64s(client.Security.PermittedRoles),
+				payload.ParseUint64s(client.Security.ProhibitedRoles),
+				payload.ParseUint64s(client.Security.ForcedRoles),
+				roles...,
+			)
 		}
 
 		// User authenticated, client authorized!

--- a/pkg/auth/role-security.go
+++ b/pkg/auth/role-security.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"sort"
+
+	"github.com/cortezaproject/corteza-server/pkg/slice"
+)
+
+// ApplyRoleSecurity takes role security params (set of permitted, prohibited and forced roles)
+// and applies these rules to the set of given roles
+//
+// Filtered set of roles is returned
+//
+// String slices are used intentionally, because of the data source used
+func ApplyRoleSecurity(permitted, prohibited, forced []uint64, rr ...uint64) (out []uint64) {
+	var (
+		mPermitted  = slice.ToUint64BoolMap(permitted)
+		mProhibited = slice.ToUint64BoolMap(prohibited)
+		mForced     = slice.ToUint64BoolMap(forced)
+	)
+
+	// iterate over user's roles and just append them (obeying allow&deny rules)
+	// to list of mForced roles
+	for _, r := range rr {
+		if (len(mPermitted) == 0 || mPermitted[r]) && !mProhibited[r] {
+			mForced[r] = true
+		}
+	}
+
+	out = make([]uint64, 0, len(mForced))
+	for forcedRoleID := range mForced {
+		out = append(out, forcedRoleID)
+	}
+
+	// for stable output
+	sort.Slice(out, func(i, j int) bool {
+		return out[i] < out[j]
+	})
+
+	return
+}

--- a/pkg/auth/role-security_test.go
+++ b/pkg/auth/role-security_test.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyRoleSecurity(t *testing.T) {
+	tests := []struct {
+		name       string
+		permitted  []uint64
+		prohibited []uint64
+		forced     []uint64
+		roles      []uint64
+		wantOut    []uint64
+	}{
+		{
+			"empty",
+			[]uint64{},
+			[]uint64{},
+			[]uint64{},
+			[]uint64{},
+			[]uint64{},
+		},
+		{
+			"nil",
+			nil,
+			nil,
+			nil,
+			nil,
+			[]uint64{},
+		},
+		{
+			"one",
+			[]uint64{1},
+			[]uint64{2},
+			[]uint64{3},
+			[]uint64{1, 2},
+			[]uint64{1, 3},
+		},
+		{
+			"forced only",
+			[]uint64{},
+			[]uint64{},
+			[]uint64{3, 2, 1},
+			[]uint64{2},
+			[]uint64{1, 2, 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantOut, ApplyRoleSecurity(tt.permitted, tt.prohibited, tt.forced, tt.roles...))
+		})
+	}
+}

--- a/system/types/app_settings.go
+++ b/system/types/app_settings.go
@@ -96,6 +96,8 @@ type (
 						IdentHandle     string `kv:"ident-handle"`
 						IdentIdentifier string `kv:"ident-identifier"`
 					} `kv:"idp"`
+
+					Security ExternalAuthProviderSecurity `json:"-" kv:"security,final"`
 				}
 
 				// all external providers we know
@@ -209,6 +211,38 @@ type (
 		RedirectUrl string `json:"-" kv:"redirect"`
 		IssuerUrl   string `json:"-" kv:"issuer"`
 		Weight      int    `json:"-"`
+
+		Security ExternalAuthProviderSecurity `json:"-" kv:"security,final"`
+	}
+
+	ExternalAuthProviderSecurity struct {
+		// Subset of roles, permitted to be used with this client
+		// when authorizing via this auth provider.
+		//
+		// IDs are intentionally stored as strings to support JS (int64 only)
+		//
+		PermittedRoles []string `json:"permittedRoles,omitempty"`
+
+		// Subset of roles, prohibited to be used with this client
+		// when authorizing via this auth provider.
+		//
+		// IDs are intentionally stored as strings to support JS (int64 only)
+		//
+		ProhibitedRoles []string `json:"prohibitedRoles,omitempty"`
+
+		// Set of additional roles that are forced on this user
+		// when authorizing via this auth provider.
+		//
+		// IDs are intentionally stored as strings to support JS (int64 only)
+		ForcedRoles []string `json:"forcedRoles,omitempty"`
+
+		// Map external roles or groups to internal
+		//
+		// If IdP provides a list of roles (groups) along side authenticated user
+		// these roles can be mapped to the valid local roles
+		//
+		// @todo implement mapped roles
+		// MappedRoles map[string]string `json:"mappedRoles,omitempty"`
 	}
 
 	SmtpServers struct {

--- a/system/types/auth_client.go
+++ b/system/types/auth_client.go
@@ -4,11 +4,9 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/cortezaproject/corteza-server/pkg/filter"
-	"github.com/cortezaproject/corteza-server/pkg/slice"
 )
 
 type (
@@ -220,33 +218,4 @@ func (vv *AuthClientSecurity) Value() (driver.Value, error) {
 	}
 
 	return json.Marshal(vv)
-}
-
-// Takes user's roles, filter out only allowed roles (when set), remove denied and add all forced
-func (vv *AuthClientSecurity) ProcessRoles(rr ...uint64) (out []uint64) {
-	var (
-		permitted  = slice.ToStringBoolMap(vv.PermittedRoles)
-		prohibited = slice.ToStringBoolMap(vv.ProhibitedRoles)
-		forced     = slice.ToStringBoolMap(vv.ForcedRoles)
-		aux        string
-		roleID     uint64
-	)
-
-	// iterate over user's roles and just append them (obeying allow&deny rules)
-	// to list of forced roles
-	for _, r := range rr {
-		aux = strconv.FormatUint(r, 10)
-		if (len(vv.PermittedRoles) == 0 || permitted[aux]) && !prohibited[aux] {
-			forced[aux] = true
-		}
-	}
-
-	out = make([]uint64, 0, len(forced))
-	for i := range forced {
-		if roleID, _ = strconv.ParseUint(i, 10, 64); roleID > 0 {
-			out = append(out, roleID)
-		}
-	}
-
-	return
 }


### PR DESCRIPTION
Refactors role security as it was implemented on auth-clients into more reusable function.
Implement same/similar role-security structure on external auth providers and allow permitted/prohibited/forbidden roles to be applied when user authenticates via IdP.