### PR TITLE
Fix bool/false value sanitization

### DIFF
--- a/compose/service/values/sanitizer.go
+++ b/compose/service/values/sanitizer.go
@@ -188,7 +188,8 @@ func sBool(v interface{}) string {
 		}
 	}
 
-	return strBoolFalse
+	// Returning empty string here to align false value with everything else
+	return strBoolFalseAlt
 }
 
 func sDatetime(v interface{}, onlyDate, onlyTime bool) string {

--- a/compose/service/values/sanitizer_test.go
+++ b/compose/service/values/sanitizer_test.go
@@ -68,13 +68,13 @@ func Test_sanitizer_Run(t *testing.T) {
 			name:   "booleans should be converted (false)",
 			kind:   "Bool",
 			input:  "false",
-			output: "0",
+			output: "",
 		},
 		{
 			name:   "booleans should be converted (garbage)",
 			kind:   "Bool",
 			input:  "%%#)%)')$)'",
-			output: "0",
+			output: "",
 		},
 		{
 			name:   "dates should be converted to ISO",

--- a/compose/service/values/shared.go
+++ b/compose/service/values/shared.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	strBoolTrue  = "1"
-	strBoolFalse = "0"
+	strBoolTrue     = "1"
+	strBoolFalse    = "0"
+	strBoolFalseAlt = ""
 
 	datetimeInternalFormatDate = "2006-01-02"
 	datetimeIntenralFormatTime = "15:04:05"

--- a/compose/service/values/validator.go
+++ b/compose/service/values/validator.go
@@ -250,7 +250,7 @@ func (vldtr validator) vBool(v *types.RecordValue, f *types.ModuleField, r *type
 		return nil
 	}
 
-	if v.Value != strBoolTrue && v.Value != strBoolFalse {
+	if v.Value != strBoolTrue && v.Value != strBoolFalse && v.Value != strBoolFalseAlt {
 		return e2s(makeInvalidValueErr(f, v.Value))
 	}
 


### PR DESCRIPTION
Boolean value sanitization MUST return empty string for false boolean
value to ensure consisten behaviour when empty or false value for field
is send back and that field is read-only (via RBAC).

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
