### PR TITLE
Refactor min.io object storage

### DIFF
--- a/app/boot_levels.go
+++ b/app/boot_levels.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"strings"
 
 	authService "github.com/cortezaproject/corteza-server/auth"
@@ -75,6 +76,18 @@ func (app *CortezaApp) Setup() (err error) {
 			log.Warn("You're using SQLite as a storage backend")
 			log.Warn("Should be used only for testing")
 			log.Warn("You may experience unstability and data loss")
+		}
+
+		if _, is := os.LookupEnv("MINIO_BUCKET_SEP"); is {
+			log.Warn("Found MINIO_BUCKET_SEP in environment variables, it has been removed")
+
+			return fmt.Errorf(
+				"invalid minio configurtion: " +
+					"found MINIO_BUCKET_SEP in environment variables, " +
+					"which is removed due to latest versions of min.io " +
+					"bucket names can only consist of lowercase letters, numbers, dots (.), and hyphens (-). " +
+					"so instead use environment variable MINIO_BUCKET, " +
+					"we have extended it to have more flexibility over minio bucket name")
 		}
 	}
 

--- a/pkg/objstore/minio/store_test.go
+++ b/pkg/objstore/minio/store_test.go
@@ -1,0 +1,234 @@
+package minio
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/minio/minio-go/v6"
+	"github.com/minio/minio-go/v6/pkg/s3utils"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+)
+
+type (
+	testMinio struct{}
+)
+
+func (t testMinio) BucketExists(bucketName string) (out bool, err error) {
+	return
+}
+
+func (t testMinio) MakeBucket(bucketName string, location string) (err error) {
+	return
+}
+
+func (t testMinio) PutObject(bucketName, objectName string, reader io.Reader, objectSize int64, opts minio.PutObjectOptions) (n int64, err error) {
+	return
+}
+
+func (t testMinio) RemoveObject(bucketName, objectName string) (err error) {
+	return
+}
+
+func (t testMinio) GetObject(bucketName, objectName string, opts minio.GetObjectOptions) (out *minio.Object, err error) {
+	return
+}
+
+func TestBucketName(t *testing.T) {
+	type (
+		tf struct {
+			// Input
+			bucketName string
+			// Expected result
+			errMsg string
+			// Flag to indicate whether test should Pass
+			valid bool
+		}
+	)
+
+	var (
+		req = require.New(t)
+		tcc = []tf{
+			{
+				bucketName: ".testbucket",
+				errMsg:     "Bucket name contains invalid characters",
+				valid:      false,
+			},
+			{
+				bucketName: "testbucket.",
+				errMsg:     "Bucket name contains invalid characters",
+				valid:      false,
+			},
+			{
+				bucketName: "testbucket-",
+				errMsg:     "Bucket name contains invalid characters",
+				valid:      false,
+			},
+			{
+				bucketName: "testbucket/",
+				errMsg:     "Bucket name contains invalid characters",
+				valid:      false,
+			},
+
+			{
+				bucketName: "te",
+				errMsg:     "Bucket name cannot be smaller than 3 characters",
+				valid:      false,
+			},
+			{
+				bucketName: "",
+				errMsg:     "Bucket name cannot be empty",
+				valid:      false,
+			},
+			{
+				bucketName: "test..bucket",
+				errMsg:     "Bucket name contains invalid characters",
+				valid:      false,
+			},
+			{
+				bucketName: "test.bucket.com",
+				errMsg:     "",
+				valid:      true,
+			},
+			{
+				bucketName: "test-bucket",
+				errMsg:     "",
+				valid:      true,
+			},
+			{
+				bucketName: "123test-bucket",
+				errMsg:     "",
+				valid:      true,
+			},
+		}
+	)
+
+	for i, tc := range tcc {
+		_ = req
+		_ = i
+
+		err := s3utils.CheckValidBucketName(tc.bucketName)
+		if tc.errMsg != "" {
+			req.Equal(tc.errMsg, err.Error(), tc.errMsg)
+		} else {
+			req.NoError(err)
+		}
+	}
+}
+
+func TestStore(t *testing.T) {
+	type (
+		tf struct {
+			name               string
+			bucket             string
+			pathPrefix         string
+			componentName      string
+			expectedBucketName string
+			expectedError      error
+		}
+	)
+
+	var (
+		mc  testMinio
+		tcc = []tf{
+			{
+				name:               "default bucket",
+				bucket:             "{component}",
+				componentName:      "test",
+				expectedBucketName: "test",
+			},
+			{
+				name:               "custom bucket",
+				bucket:             "corteza-{component}",
+				componentName:      "test",
+				expectedBucketName: "corteza-test",
+			},
+			{
+				name:               "custom bucket",
+				bucket:             "corteza-{component}",
+				componentName:      "test",
+				expectedBucketName: "corteza-test",
+			},
+			{
+				name:               "custom bucket",
+				bucket:             "corteza-{component}",
+				componentName:      "test",
+				expectedBucketName: "corteza-test",
+			},
+			{
+				name:          "bucket has invalid character(/)",
+				bucket:        "corteza/{component}",
+				componentName: "test",
+				expectedError: fmt.Errorf("Bucket name contains invalid characters"),
+			},
+			{
+				name:          "bucket has invalid character(-) at the end of the name",
+				bucket:        "{component}-",
+				componentName: "test",
+				expectedError: fmt.Errorf("Bucket name contains invalid characters"),
+			},
+		}
+	)
+
+	for _, tc := range tcc {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				req    = require.New(t)
+				bucket = GetBucket(tc.bucket, tc.componentName)
+			)
+
+			store, err := newWithClient(mc, bucket, tc.pathPrefix, tc.componentName, Options{})
+			req.Equal(tc.expectedError, err)
+			if tc.expectedError == nil {
+				req.Equal(tc.expectedBucketName, store.bucket, "Unexpected bucket name")
+			}
+
+			if store != nil {
+				{
+					fn := store.Original(123, "txt")
+					expected := "123.txt"
+					req.True(fn == expected, "Unexpected filename returned: %s != %s", expected, fn)
+				}
+
+				{
+					fn := store.Preview(123, "txt")
+					expected := "123_preview.txt"
+					req.True(fn == expected, "Unexpected filename returned: %s != %s", expected, fn)
+				}
+
+				// @todo extend below test to check expected path, content of the object
+				// 		after write, read and delete
+				// write a file
+				{
+					buf := bytes.NewBuffer([]byte("This is a testing buffer"))
+					err := store.Save("test/123.txt", buf)
+					req.True(err == nil, "Error saving file, %+v", err)
+
+					err = store.Save("test123/123.txt", buf)
+					req.True(err == nil, "Expected error when saving file outside of namespace")
+				}
+
+				// read a file
+				{
+					_, err := store.Open("test/123.txt")
+					req.True(err == nil, "Unexpected error when reading file: %+v", err)
+
+					_, err = store.Open("test/1234.txt")
+					req.True(err == nil, "Expected error when opening non-existent file")
+					_, err = store.Open("test123/123.txt")
+					req.True(err == nil, "Expected error when opening file outside of namespace")
+				}
+
+				// delete a file
+				{
+					err := store.Remove("test/123.txt")
+					req.True(err == nil, "Unexpected error when removing file: %+v", err)
+					err = store.Remove("test/123.txt")
+					req.True(err == nil, "Expected error when removing missing file")
+					err = store.Remove("test123/123.txt")
+					req.True(err == nil, "Expected error when deleting file outside of namespace")
+				}
+			}
+		})
+	}
+}

--- a/pkg/options/objectStore.gen.go
+++ b/pkg/options/objectStore.gen.go
@@ -10,25 +10,25 @@ package options
 
 type (
 	ObjectStoreOpt struct {
-		Path           string `env:"STORAGE_PATH"`
-		MinioEndpoint  string `env:"MINIO_ENDPOINT"`
-		MinioSecure    bool   `env:"MINIO_SECURE"`
-		MinioAccessKey string `env:"MINIO_ACCESS_KEY"`
-		MinioSecretKey string `env:"MINIO_SECRET_KEY"`
-		MinioSSECKey   string `env:"MINIO_SSEC_KEY"`
-		MinioBucket    string `env:"MINIO_BUCKET"`
-		MinioBucketSep string `env:"MINIO_BUCKET_SEP"`
-		MinioStrict    bool   `env:"MINIO_STRICT"`
+		Path            string `env:"STORAGE_PATH"`
+		MinioEndpoint   string `env:"MINIO_ENDPOINT"`
+		MinioSecure     bool   `env:"MINIO_SECURE"`
+		MinioAccessKey  string `env:"MINIO_ACCESS_KEY"`
+		MinioSecretKey  string `env:"MINIO_SECRET_KEY"`
+		MinioSSECKey    string `env:"MINIO_SSEC_KEY"`
+		MinioBucket     string `env:"MINIO_BUCKET"`
+		MinioPathPrefix string `env:"MINIO_PATH_PREFIX"`
+		MinioStrict     bool   `env:"MINIO_STRICT"`
 	}
 )
 
 // ObjectStore initializes and returns a ObjectStoreOpt with default values
 func ObjectStore() (o *ObjectStoreOpt) {
 	o = &ObjectStoreOpt{
-		Path:           "var/store",
-		MinioSecure:    true,
-		MinioBucketSep: "/",
-		MinioStrict:    false,
+		Path:        "var/store",
+		MinioSecure: true,
+		MinioBucket: "{component}",
+		MinioStrict: false,
 	}
 
 	fill(o)

--- a/pkg/options/objectStore.yaml
+++ b/pkg/options/objectStore.yaml
@@ -29,11 +29,14 @@ props:
 
   - name: minioBucket
     env: MINIO_BUCKET
+    default: "{component}"
+    description: |-
+      `component` placeholder is replaced with service name (e.g system).
 
-  - name: minioBucketSep
-    env: MINIO_BUCKET_SEP
-    default: "/"
-    description: Used between MINIO_BUCKET and the service name (e.g system). Ignored if MINIO_BUCKET is not set. Required in latest versions of min.io since "/" is not accepted anymore in bucket names.
+  - name: minioPathPrefix
+    env: MINIO_PATH_PREFIX
+    description: |-
+      `component` placeholder is replaced with service name (e.g system).
 
   - name: minioStrict
     type: bool

--- a/system/service/service.go
+++ b/system/service/service.go
@@ -125,29 +125,30 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, ws websock
 	DefaultSettings = Settings(ctx, DefaultStore, DefaultLogger, DefaultAccessControl, CurrentSettings)
 
 	if DefaultObjectStore == nil {
+		var (
+			opt    = c.Storage
+			bucket string
+		)
 		const svcPath = "system"
-		if c.Storage.MinioEndpoint != "" {
-			var bucket = svcPath
-			if c.Storage.MinioBucket != "" {
-				bucket = c.Storage.MinioBucket + c.Storage.MinioBucketSep + svcPath
-			}
+		if opt.MinioEndpoint != "" {
+			bucket = minio.GetBucket(opt.MinioBucket, svcPath)
 
-			DefaultObjectStore, err = minio.New(bucket, minio.Options{
-				Endpoint:        c.Storage.MinioEndpoint,
-				Secure:          c.Storage.MinioSecure,
-				Strict:          c.Storage.MinioStrict,
-				AccessKeyID:     c.Storage.MinioAccessKey,
-				SecretAccessKey: c.Storage.MinioSecretKey,
+			DefaultObjectStore, err = minio.New(bucket, opt.MinioPathPrefix, svcPath, minio.Options{
+				Endpoint:        opt.MinioEndpoint,
+				Secure:          opt.MinioSecure,
+				Strict:          opt.MinioStrict,
+				AccessKeyID:     opt.MinioAccessKey,
+				SecretAccessKey: opt.MinioSecretKey,
 
-				ServerSideEncryptKey: []byte(c.Storage.MinioSSECKey),
+				ServerSideEncryptKey: []byte(opt.MinioSSECKey),
 			})
 
 			log.Info("initializing minio",
 				zap.String("bucket", bucket),
-				zap.String("endpoint", c.Storage.MinioEndpoint),
+				zap.String("endpoint", opt.MinioEndpoint),
 				zap.Error(err))
 		} else {
-			path := c.Storage.Path + "/" + svcPath
+			path := opt.Path + "/" + svcPath
 			DefaultObjectStore, err = plain.New(path)
 			log.Info("initializing store",
 				zap.String("path", path),


### PR DESCRIPTION
- Introduces env variable for `MINIO_PATH_PREFIX` for more flexibility over bucket naming
- Provides method for generating bucket name from bucket related env variables
- Decouples minio client from New method
- Adds tests

 Related to Issue #295

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
