### PR TITLE
Allow version in DB_DSN for dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ HTTP_LOG_REQUESTS=true
 MONITOR_INTERVAL=5min
 
 # Database to use
+#
+# If you are in development environment,
+# you can use {version} with database name, that will be replaced with build version
+# IE. DB_DSN=corteza:corteza@tcp(localhost:3306)/corteza_{version}?collation=utf8mb4_general_ci
 DB_DSN=corteza:corteza@tcp(localhost:3306)/corteza?collation=utf8mb4_general_ci
 
 # Log database queries?

--- a/app/boot_levels.go
+++ b/app/boot_levels.go
@@ -181,7 +181,7 @@ func (app *CortezaApp) InitStore(ctx context.Context) (err error) {
 	if app.Store == nil {
 		defer sentry.Recover()
 
-		app.Store, err = store.Connect(ctx, app.Opt.DB.DSN)
+		app.Store, err = store.Connect(ctx, app.Log, app.Opt.DB.DSN, app.Opt.Environment.IsDevelopment())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If server is executed through Makefile we set BUILD_VERSION in .env and use it to replace {version} in DB_DSN.

This would help developers to automatically use different db when switching between versions.

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
