### PR TITLE
Refactor OIDC provider scope string

### DIFF
--- a/auth/external/goth.go
+++ b/auth/external/goth.go
@@ -52,8 +52,10 @@ func SetupGothProviders(log *zap.Logger, redirectUrl string, ep ...settings.Prov
 
 			wellKnown := strings.TrimSuffix(pc.IssuerUrl, "/") + WellKnown
 
-			scope := strings.Split(pc.Scope, " ")
-			if len(scope) == 0 {
+			var scope []string
+			if len(pc.Scope) > 0 {
+				scope = strings.Split(pc.Scope, " ")
+			} else {
 				scope = append(scope, "email")
 			}
 


### PR DESCRIPTION
Fixes issue for a provider with empty scope string(It should add default scope `email`).

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
