### PR TITLE
2022.3.x auth limiting

### DIFF
--- a/system/service/auth_actions.gen.go
+++ b/system/service/auth_actions.gen.go
@@ -1748,6 +1748,42 @@ func AuthErrInvalidEmailOTP(mm ...*authActionProps) *errors.Error {
 	return e
 }
 
+// AuthErrRateLimitExceeded returns "system:auth.rateLimitExceeded" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func AuthErrRateLimitExceeded(mm ...*authActionProps) *errors.Error {
+	var p = &authActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("rate limit exceeded", nil),
+
+		errors.Meta("type", "rateLimitExceeded"),
+		errors.Meta("resource", "system:auth"),
+
+		// action log entry; no formatting, it will be applied inside recordAction fn.
+		errors.Meta(authLogMetaKey{}, "rate limit exceeded for {{user}}"),
+		errors.Meta(authPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth.errors.rateLimitExceeded"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
 // AuthErrMaxUserLimitReached returns "system:auth.maxUserLimitReached" as *errors.Error
 //
 //

--- a/system/service/auth_actions.yaml
+++ b/system/service/auth_actions.yaml
@@ -203,6 +203,10 @@ errors:
     message: "invalid code"
     severity: warning
 
+  - error: rateLimitExceeded
+    message: "rate limit exceeded"
+    log: "rate limit exceeded for {{user}}"
+
   - error: maxUserLimitReached
     message: "you have reached your user limit, contact your Corteza administrator"
     severity: warning


### PR DESCRIPTION
* Reject request in case new tokens were issues but old ones were used
* Reject request if exceeds rate limit

All of the above is done from the existing state so no DB modifications are needed.