### PR TITLE
Prevent workflow worker from stopping in case of delayed steps

### DIFF
--- a/pkg/wfexec/session.go
+++ b/pkg/wfexec/session.go
@@ -440,6 +440,12 @@ func (s *Session) worker(ctx context.Context) {
 
 			s.log.Debug("pulled state from queue", zap.Uint64("stateID", st.stateId))
 			if st.step == nil {
+				// We should not terminate if the session contains any delayed or prompted steps.
+				status := s.Status()
+				if status == SessionPrompted || status == SessionDelayed {
+					break
+				}
+
 				s.log.Debug("done, setting results and stopping the worker")
 
 				func() {


### PR DESCRIPTION
Backport to 2021.9

In such case
![Screenshot from 2022-02-23 14-24-55](https://user-images.githubusercontent.com/12545711/155328087-9153cbb2-28fd-4e02-90a4-02147a0158d1.png)
where there were two parallel branches; if the two branches used some delay/prompt step, the first terminated the whole thing without waiting for the second scheduled step.

This occurred due to us not checking for delayed/prompted steps